### PR TITLE
Fortan indexing

### DIFF
--- a/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/cndrv1.c
+++ b/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/cndrv1.c
@@ -332,149 +332,102 @@ EXIT:
     return ierr;
 }
 
-/* ========================================================================== */
-
-/*     matrix vector subroutine */
-
-/*     The matrix used is the convection-diffusion operator */
-/*     discretized using centered difference. */
-
+/** Matrix vector subroutine.
+ *
+ * The matrix used is the convection-diffusion operator
+ * discretized using centered difference.
+ * 
+ * Computes w <--- OP*v, where OP is the nx*nx by nx*nx block
+ * tridiagonal matrix
+ *
+ *              | T -I          |
+ *              |-I  T -I       |
+ *         OP = |   -I  T       |
+ *              |        ...  -I|
+ *              |           -I T|
+ *
+ * derived from the standard central difference  discretization
+ * of the 2-dimensional convection-diffusion operator
+ *              (Laplacian u) + rho*(du/dx)
+ * on the unit squqre with zero boundary condition.
+ *
+ * The subroutine TV is called to computed y<---T*x.
+ */
 int cndrv1_av_(const int nx, complex *v, complex *w)
 {
     /* System generated locals */
     int i__1;
-    complex q__1, q__2;
-
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *);
 
     /* Local variables */
     int j;
-    complex h2;
     int lo;
-
-    /*     Computes w <--- OP*v, where OP is the nx*nx by nx*nx block */
-    /*     tridiagonal matrix */
-
-    /*                  | T -I          | */
-    /*                  |-I  T -I       | */
-    /*             OP = |   -I  T       | */
-    /*                  |        ...  -I| */
-    /*                  |           -I T| */
-
-    /*     derived from the standard central difference  discretization */
-    /*     of the convection-diffusion operator (Laplacian u) + rho*(du/dx) */
-    /*     with zero boundary condition. */
-
-    /*     The subroutine TV is called to computed y<---T*x. */
+    float h2;
+    complex z;
 
     /* Parameter adjustments */
     --w;
     --v;
 
     /* Function Body */
-    i__1 = (nx + 1) * (nx + 1);
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h2.r = q__1.r, h2.i = q__1.i;
+    h2 = 1.0f / (float)((nx + 1) * (nx + 1));
+
+    z.r = -1.0f / h2;
+    z.i = -0.0f;
 
     cndrv1_tv_(nx, &v[1], &w[1]);
-    q__2.r = -1.f, q__2.i = -0.0f;
-    c_div(&q__1, &q__2, &h2);
-    caxpy_(&nx, &q__1, &v[nx + 1], &c__1, &w[1], &c__1);
+    caxpy_(&nx, &z, &v[nx + 1], &c__1, &w[1], &c__1);
 
     i__1 = nx - 1;
     for (j = 2; j <= i__1; ++j)
     {
         lo = (j - 1) * nx;
         cndrv1_tv_(nx, &v[lo + 1], &w[lo + 1]);
-        q__2.r = -1.f, q__2.i = -0.0f;
-        c_div(&q__1, &q__2, &h2);
-        caxpy_(&nx, &q__1, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
-        q__2.r = -1.f, q__2.i = -0.0f;
-        c_div(&q__1, &q__2, &h2);
-        caxpy_(&nx, &q__1, &v[lo + nx + 1], &c__1, &w[lo + 1], &c__1);
+        caxpy_(&nx, &z, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
+        caxpy_(&nx, &z, &v[lo + nx + 1], &c__1, &w[lo + 1], &c__1);
     }
 
     lo = (nx - 1) * nx;
     cndrv1_tv_(nx, &v[lo + 1], &w[lo + 1]);
-    q__2.r = -1.f, q__2.i = -0.0f;
-    c_div(&q__1, &q__2, &h2);
-    caxpy_(&nx, &q__1, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
+    caxpy_(&nx, &z, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
 
     return 0;
 } /* av_ */
 
-/* ========================================================================= */
+/**
+ * Compute the matrix vector multiplication y<---T*x
+ * where T is a nx by nx tridiagonal matrix with DD on the
+ * diagonal, DL on the subdiagonal, and DU on the superdiagonal
+ */
 int cndrv1_tv_(const int nx, complex *x, complex *y)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    complex q__1, q__2, q__3, q__4, q__5;
-
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
-    complex h;
     int j;
-    complex h2, dd, dl, du;
-
-    /*     Compute the matrix vector multiplication y<---T*x */
-    /*     where T is a nx by nx tridiagonal matrix with DD on the */
-    /*     diagonal, DL on the subdiagonal, and DU on the superdiagonal */
-
-    /* Parameter adjustments */
-    --y;
-    --x;
+    float h, h2, dd, dl, du;
 
     /* Function Body */
-    i__1 = nx + 1;
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h.r = q__1.r, h.i = q__1.i;
-    q__1.r = h.r * h.r - h.i * h.i, q__1.i = h.r * h.i + h.i * h.r;
-    h2.r = q__1.r, h2.i = q__1.i;
-    c_div(&q__1, &c_four, &h2);
-    dd.r = q__1.r, dd.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h2);
-    q__5.r = 50.0f, q__5.i = 0.0f;
-    c_div(&q__4, &q__5, &h);
-    q__1.r = q__2.r - q__4.r, q__1.i = q__2.i - q__4.i;
-    dl.r = q__1.r, dl.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h2);
-    q__5.r = 50.0f, q__5.i = 0.0f;
-    c_div(&q__4, &q__5, &h);
-    q__1.r = q__2.r + q__4.r, q__1.i = q__2.i + q__4.i;
-    du.r = q__1.r, du.i = q__1.i;
+    h = 1.0f / (float)(nx + 1);
+    h2 = h * h;
+    dd = 4.0f / h2;
+    dl = -1.0f / h2 - 50.0f / h;
+    du = -1.0f / h2 + 50.0f / h;
 
-    q__2.r = dd.r * x[1].r - dd.i * x[1].i, q__2.i = dd.r * x[1].i + dd.i * x[1].r;
-    q__3.r = du.r * x[2].r - du.i * x[2].i, q__3.i = du.r * x[2].i + du.i * x[2].r;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    y[1].r = q__1.r, y[1].i = q__1.i;
+    y[0].r = dd * x[0].r + du * x[1].r;
+    y[0].i = dd * x[0].i + du * x[1].i;
+
     i__1 = nx - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        q__3.r = dl.r * x[i__3].r - dl.i * x[i__3].i, q__3.i = dl.r * x[i__3].i + dl.i * x[i__3].r;
-        i__4 = j;
-        q__4.r = dd.r * x[i__4].r - dd.i * x[i__4].i, q__4.i = dd.r * x[i__4].i + dd.i * x[i__4].r;
-        q__2.r = q__3.r + q__4.r, q__2.i = q__3.i + q__4.i;
-        i__5 = j + 1;
-        q__5.r = du.r * x[i__5].r - du.i * x[i__5].i, q__5.i = du.r * x[i__5].i + du.i * x[i__5].r;
-        q__1.r = q__2.r + q__5.r, q__1.i = q__2.i + q__5.i;
-        y[i__2].r = q__1.r, y[i__2].i = q__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        y[j].r = (dl * x[i__2].r + dd * x[j].r) + du * x[i__3].r;
+        y[j].i = (dl * x[i__2].i + dd * x[j].i) + du * x[i__3].i;
     }
-    i__1 = nx;
-    i__2 = nx - 1;
-    q__2.r = dl.r * x[i__2].r - dl.i * x[i__2].i, q__2.i = dl.r * x[i__2].i + dl.i * x[i__2].r;
-    i__3 = nx;
-    q__3.r = dd.r * x[i__3].r - dd.i * x[i__3].i, q__3.i = dd.r * x[i__3].i + dd.i * x[i__3].r;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    y[i__1].r = q__1.r, y[i__1].i = q__1.i;
+    i__1 = nx - 1;
+    i__2 = nx - 2;
+    y[i__1].r = dl * x[i__2].r + dd * x[i__1].r;
+    y[i__1].i = dl * x[i__2].i + dd * x[i__1].i;
     return 0;
 } /* tv_ */
-

--- a/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/cndrv2.c
+++ b/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/cndrv2.c
@@ -3,12 +3,7 @@
 #include <stdlib.h>
 #include "arpack.h"
 
-struct
-{
-    complex rho;
-} convct_;
-
-#define convct_1 convct_
+#define RHO 10.0f
 
 /**
  * \BeginDoc
@@ -53,9 +48,7 @@ int cndrv2()
 {
     /* System generated locals */
     int i__1, i__2;
-    complex q__1, q__2, q__3, q__4;
-
-    void c_div(complex *, complex *, complex *);
+    complex q__1;
 
     /* Local variables */
     complex d[25];
@@ -63,8 +56,8 @@ int cndrv2()
     float rd[75] /* (3 * MAXNCV) */;
     float rwork[256];
 
-    complex h, s, h2, s1, s2, s3;
-    complex sigma;
+    float h, s, h2, s1, s3;
+    complex sigma, s2;
 
     int j;
     int ierr, nconv;
@@ -133,39 +126,21 @@ int cndrv2()
     complex* dl = (complex*)malloc(n * sizeof(complex));
     complex* du2 = (complex*)malloc(n * sizeof(complex));
 
-    convct_1.rho.r = 10.0f, convct_1.rho.i = 0.0f;
-    i__1 = n + 1;
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h.r = q__1.r, h.i = q__1.i;
-    q__1.r = h.r * h.r - h.i * h.i, q__1.i = h.r * h.i + h.i * h.r;
-    h2.r = q__1.r, h2.i = q__1.i;
-    c_div(&q__1, &convct_1.rho, &c_two);
-    s.r = q__1.r, s.i = q__1.i;
+    h = 1.0f / (float)(n + 1);
+    h2 = h * h;
+    s = RHO / 2.0f;
 
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h2);
-    c_div(&q__4, &s, &h);
-    q__1.r = q__2.r - q__4.r, q__1.i = q__2.i - q__4.i;
-    s1.r = q__1.r, s1.i = q__1.i;
-    c_div(&q__2, &c_two, &h2);
-    q__1.r = q__2.r - sigma.r, q__1.i = q__2.i - sigma.i;
-    s2.r = q__1.r, s2.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h2);
-    c_div(&q__4, &s, &h);
-    q__1.r = q__2.r + q__4.r, q__1.i = q__2.i + q__4.i;
-    s3.r = q__1.r, s3.i = q__1.i;
+    s1 = -1.0f / h2 - s / h;
+    s2.r = 2.0f / h2 - sigma.r, s2.i = -sigma.i;
+    s3 = -1.0f / h2 + s / h;
 
     i__1 = n - 1;
     for (j = 1; j <= i__1; ++j)
     {
         i__2 = j - 1;
-        dl[i__2].r = s1.r, dl[i__2].i = s1.i;
-        i__2 = j - 1;
+        dl[i__2].r = s1, dl[i__2].i = 0.0f;
         dd[i__2].r = s2.r, dd[i__2].i = s2.i;
-        i__2 = j - 1;
-        du[i__2].r = s3.r, du[i__2].i = s3.i;
+        du[i__2].r = s3, du[i__2].i = 0.0f;
     }
     i__1 = n - 1;
     dd[i__1].r = s2.r, dd[i__1].i = s2.i;
@@ -412,75 +387,40 @@ EXIT:
     return ierr;
 }
 
-/* ------------------------------------------------------------------- */
-
-/*     matrix vector multiplication subroutine */
-
+/**
+ * Matrix vector multiplication subroutine.
+ */
 int cndrv2_av_(const int n, complex *v, complex *w)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    complex q__1, q__2, q__3, q__4, q__5;
-
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
-    complex h;
     int j;
-    complex s, h2, dd, dl, du;
-
-    /* Parameter adjustments */
-    --w;
-    --v;
+    float h, s, h2, dd, dl, du;
 
     /* Function Body */
-    i__1 = n + 1;
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h.r = q__1.r, h.i = q__1.i;
-    q__1.r = h.r * h.r - h.i * h.i, q__1.i = h.r * h.i + h.i * h.r;
-    h2.r = q__1.r, h2.i = q__1.i;
-    c_div(&q__1, &convct_1.rho, &c_two);
-    s.r = q__1.r, s.i = q__1.i;
-    c_div(&q__1, &c_two, &h2);
-    dd.r = q__1.r, dd.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h2);
-    c_div(&q__4, &s, &h);
-    q__1.r = q__2.r - q__4.r, q__1.i = q__2.i - q__4.i;
-    dl.r = q__1.r, dl.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h2);
-    c_div(&q__4, &s, &h);
-    q__1.r = q__2.r + q__4.r, q__1.i = q__2.i + q__4.i;
-    du.r = q__1.r, du.i = q__1.i;
+    h = 1.0f / (float) (n + 1);
+    h2 = h * h;
+    s = RHO / 2.0f;
+    dd = 2.0f / h2;
+    dl = -1.0f / h2 - s / h;
+    du = -1.0f / h2 + s / h;
 
-    q__2.r = dd.r * v[1].r - dd.i * v[1].i, q__2.i = dd.r * v[1].i + dd.i * v[1].r;
-    q__3.r = du.r * v[2].r - du.i * v[2].i, q__3.i = du.r * v[2].i + du.i * v[2].r;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    w[1].r = q__1.r, w[1].i = q__1.i;
+    w[0].r = dd * v[0].r + du * v[1].r;
+    w[0].i = dd * v[0].i + du * v[1].i;
+
     i__1 = n - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        q__3.r = dl.r * v[i__3].r - dl.i * v[i__3].i, q__3.i = dl.r * v[i__3].i + dl.i * v[i__3].r;
-        i__4 = j;
-        q__4.r = dd.r * v[i__4].r - dd.i * v[i__4].i, q__4.i = dd.r * v[i__4].i + dd.i * v[i__4].r;
-        q__2.r = q__3.r + q__4.r, q__2.i = q__3.i + q__4.i;
-        i__5 = j + 1;
-        q__5.r = du.r * v[i__5].r - du.i * v[i__5].i, q__5.i = du.r * v[i__5].i + du.i * v[i__5].r;
-        q__1.r = q__2.r + q__5.r, q__1.i = q__2.i + q__5.i;
-        w[i__2].r = q__1.r, w[i__2].i = q__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        w[j].r = (dl * v[i__2].r + dd * v[j].r) + du * v[i__3].r;
+        w[j].i = (dl * v[i__2].i + dd * v[j].i) + du * v[i__3].i;
     }
-    i__1 = n;
-    i__2 = n - 1;
-    q__2.r = dl.r * v[i__2].r - dl.i * v[i__2].i, q__2.i = dl.r * v[i__2].i + dl.i * v[i__2].r;
-    i__3 = n;
-    q__3.r = dd.r * v[i__3].r - dd.i * v[i__3].i, q__3.i = dd.r * v[i__3].i + dd.i * v[i__3].r;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    w[i__1].r = q__1.r, w[i__1].i = q__1.i;
+    i__1 = n - 1;
+    i__2 = n - 2;
+    w[i__1].r = dl * v[i__2].r + dd * v[i__1].r;
+    w[i__1].i = dl * v[i__2].i + dd * v[i__1].i;
     return 0;
 } /* av_ */
-

--- a/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/cndrv3.c
+++ b/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/cndrv3.c
@@ -46,9 +46,7 @@ int cndrv3()
 {
     /* System generated locals */
     int i__1, i__2;
-    complex q__1, q__2;
-
-    void c_div(complex *, complex *, complex *);
+    complex q__1;
 
     /* Local variables */
     complex d[25];
@@ -120,29 +118,18 @@ int cndrv3()
     complex* dl = (complex*)malloc(n * sizeof(complex));
     complex* du2 = (complex*)malloc(n * sizeof(complex));
 
-    i__1 = n + 1;
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h.r = q__1.r, h.i = q__1.i;
+    h.r = 1.0f / (float)(n + 1);
+    h.i = 0.0f;
     i__1 = n - 1;
     for (j = 1; j <= i__1; ++j)
     {
         i__2 = j - 1;
-        q__1.r = h.r * 1.0f - h.i * 0.0f, q__1.i = h.i * 1.0f + h.r *
-                 0.0f;
-        dl[i__2].r = q__1.r, dl[i__2].i = q__1.i;
-        i__2 = j - 1;
-        q__1.r = h.r * 4.0f - h.i * 0.0f, q__1.i = h.r * 0.0f + h.i *
-                 4.0f;
-        dd[i__2].r = q__1.r, dd[i__2].i = q__1.i;
-        i__2 = j - 1;
-        q__1.r = h.r * 1.0f - h.i * 0.0f, q__1.i = h.i * 1.0f + h.r *
-                 0.0f;
-        du[i__2].r = q__1.r, du[i__2].i = q__1.i;
+        dl[i__2].r = h.r * 1.0f, dl[i__2].i = h.i * 1.0f;
+        dd[i__2].r = h.r * 4.0f, dd[i__2].i = h.i * 4.0f;
+        du[i__2].r = h.r * 1.0f, du[i__2].i = h.i * 1.0f;
     }
     i__1 = n - 1;
-    q__1.r = h.r * 4.0f - h.i * 0.0f, q__1.i = h.r * 0.0f + h.i * 4.0f;
-    dd[i__1].r = q__1.r, dd[i__1].i = q__1.i;
+    dd[i__1].r = h.r * 4.0f, dd[i__1].i = h.i * 4.0f;
 
     cgttrf_(&n, dl, dd, du, du2, ipiv, &ierr);
     if (ierr != 0)
@@ -404,134 +391,79 @@ EXIT:
     return ierr;
 }
 
-/* ========================================================================== */
-
-/*     matrix vector multiplication subroutine */
-
+/** Matrix vector multiplication subroutine.
+ *
+ * Compute the matrix vector multiplication y<---A*x
+ * where A is the stiffness matrix formed by using piecewise linear
+ * elements on [0,1].
+ */
 int cndrv3_av_(const int n, complex *v, complex *w)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    complex q__1, q__2, q__3, q__4, q__5;
-
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
-    complex h;
     int j;
-    complex s, dd, dl, du;
-
-    /*     Compute the matrix vector multiplication y<---A*x */
-    /*     where A is the stiffness matrix formed by using piecewise linear */
-    /*     elements on [0,1]. */
-
-    /* Parameter adjustments */
-    --w;
-    --v;
+    float h, s, dd, dl, du;
 
     /* Function Body */
-    i__1 = n + 1;
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h.r = q__1.r, h.i = q__1.i;
-    c_div(&q__1, &c_ten, &c_two);
-    s.r = q__1.r, s.i = q__1.i;
-    c_div(&q__1, &c_two, &h);
-    dd.r = q__1.r, dd.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h);
-    q__1.r = q__2.r - s.r, q__1.i = q__2.i - s.i;
-    dl.r = q__1.r, dl.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h);
-    q__1.r = q__2.r + s.r, q__1.i = q__2.i + s.i;
-    du.r = q__1.r, du.i = q__1.i;
+    h = 1.0f / (float)(n + 1);
+    s = 10.0f / 2.0f;
+    dd = 2.0f / h;
+    dl = -1.0f / h - s;
+    du = -1.0f / h + s;
 
-    q__2.r = dd.r * v[1].r - dd.i * v[1].i, q__2.i = dd.r * v[1].i + dd.i * v[1].r;
-    q__3.r = du.r * v[2].r - du.i * v[2].i, q__3.i = du.r * v[2].i + du.i * v[2].r;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    w[1].r = q__1.r, w[1].i = q__1.i;
+    w[0].r = dd * v[0].r + du * v[1].r;
+    w[0].i = dd * v[0].i + du * v[1].i;
+
     i__1 = n - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        q__3.r = dl.r * v[i__3].r - dl.i * v[i__3].i, q__3.i = dl.r * v[i__3].i + dl.i * v[i__3].r;
-        i__4 = j;
-        q__4.r = dd.r * v[i__4].r - dd.i * v[i__4].i, q__4.i = dd.r * v[i__4].i + dd.i * v[i__4].r;
-        q__2.r = q__3.r + q__4.r, q__2.i = q__3.i + q__4.i;
-        i__5 = j + 1;
-        q__5.r = du.r * v[i__5].r - du.i * v[i__5].i, q__5.i = du.r * v[i__5].i + du.i * v[i__5].r;
-        q__1.r = q__2.r + q__5.r, q__1.i = q__2.i + q__5.i;
-        w[i__2].r = q__1.r, w[i__2].i = q__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        w[j].r = (dl * v[i__2].r + dd * v[j].r) + du * v[i__3].r;
+        w[j].i = (dl * v[i__2].i + dd * v[j].i) + du * v[i__3].i;
     }
-    i__1 = n;
-    i__2 = n - 1;
-    q__2.r = dl.r * v[i__2].r - dl.i * v[i__2].i, q__2.i = dl.r * v[i__2].i + dl.i * v[i__2].r;
-    i__3 = n;
-    q__3.r = dd.r * v[i__3].r - dd.i * v[i__3].i, q__3.i = dd.r * v[i__3].i + dd.i * v[i__3].r;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    w[i__1].r = q__1.r, w[i__1].i = q__1.i;
+    i__1 = n - 1;
+    i__2 = n - 2;
+    w[i__1].r = dl * v[i__2].r + dd * v[i__1].r;
+    w[i__1].i = dl * v[i__2].i + dd * v[i__1].i;
     return 0;
 } /* av_ */
 
-/* ------------------------------------------------------------------------ */
+/**
+ * Compute the matrix vector multiplication y<---M*x
+ * where M is the mass matrix formed by using piecewise linear elements
+ * on [0,1].
+ */
 int cndrv3_mv_(const int n, complex *v, complex *w)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    complex q__1, q__2, q__3, q__4, q__5;
-
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
     complex h;
     int j;
 
-    /*     Compute the matrix vector multiplication y<---M*x */
-    /*     where M is the mass matrix formed by using piecewise linear elements */
-    /*     on [0,1]. */
-
-    /* Parameter adjustments */
-    --w;
-    --v;
-
     /* Function Body */
-    q__2.r = v[1].r * 4.0f - v[1].i * 0.0f, q__2.i = v[1].i * 4.0f + v[1].r *
-             0.0f;
-    q__3.r = v[2].r * 1.0f - v[2].i * 0.0f, q__3.i = v[2].i * 1.0f + v[2].r *
-             0.0f;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    w[1].r = q__1.r, w[1].i = q__1.i;
-    i__1 = n - 1;
-    for (j = 2; j <= i__1; ++j)
-    {
-        i__2 = j;
-        i__3 = j - 1;
-        q__3.r = v[i__3].r * 1.0f - v[i__3].i * 0.0f, q__3.i = v[i__3].i * 1.0f + v[i__3].r * 0.0f;
-        i__4 = j;
-        q__4.r = v[i__4].r * 4.0f - v[i__4].i * 0.0f, q__4.i = v[i__4].i * 4.0f + v[i__4].r * 0.0f;
-        q__2.r = q__3.r + q__4.r, q__2.i = q__3.i + q__4.i;
-        i__5 = j + 1;
-        q__5.r = v[i__5].r * 1.0f - v[i__5].i * 0.0f, q__5.i = v[i__5].i * 1.0f + v[i__5].r * 0.0f;
-        q__1.r = q__2.r + q__5.r, q__1.i = q__2.i + q__5.i;
-        w[i__2].r = q__1.r, w[i__2].i = q__1.i;
-    }
-    i__1 = n;
-    i__2 = n - 1;
-    q__2.r = v[i__2].r * 1.0f - v[i__2].i * 0.0f, q__2.i = v[i__2].i * 1.0f + v[i__2].r * 0.0f;
-    i__3 = n;
-    q__3.r = v[i__3].r * 4.0f - v[i__3].i * 0.0f, q__3.i = v[i__3].i * 4.0f + v[i__3].r * 0.0f;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    w[i__1].r = q__1.r, w[i__1].i = q__1.i;
+    w[0].r = v[0].r * 4.0f + v[1].r * 1.0f;
+    w[0].i = v[0].i * 4.0f + v[1].i * 1.0f;
 
-    i__1 = n + 1;
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h.r = q__1.r, h.i = q__1.i;
-    cscal_(&n, &h, &w[1], &c__1);
+    i__1 = n - 1;
+    for (j = 1; j < i__1; ++j)
+    {
+        i__2 = j - 1;
+        i__3 = j + 1;
+        w[j].r = (v[i__2].r * 1.0f + v[j].r * 4.0f) + v[i__3].r * 1.0f;
+        w[j].i = (v[i__2].i * 1.0f + v[j].i * 4.0f) + v[i__3].i * 1.0f;
+    }
+    i__1 = n - 1;
+    i__2 = n - 2;
+    w[i__1].r = v[i__2].r * 1.0f + v[i__1].r * 4.0f;
+    w[i__1].i = v[i__2].i * 1.0f + v[i__1].i * 4.0f;
+
+    h.r = 1.0f / (float)(n + 1);
+    h.i = 0.0f;
+    cscal_(&n, &h, w, &c__1);
     return 0;
 } /* mv_ */
-

--- a/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/cndrv4.c
+++ b/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/cndrv4.c
@@ -3,12 +3,7 @@
 #include <stdlib.h>
 #include "arpack.h"
 
-struct
-{
-    complex rho;
-} convct_;
-
-#define convct_1 convct_
+#define RHO 10.0f
 
 /**
  * \BeginDoc
@@ -56,9 +51,7 @@ int cndrv4()
 {
     /* System generated locals */
     int i__1, i__2;
-    complex q__1, q__2, q__3, q__4, q__5, q__6;
-
-    void c_div(complex *, complex *, complex *);
+    complex q__1;
 
     /* Local variables */
     complex d[25];
@@ -66,8 +59,8 @@ int cndrv4()
     float rd[75] /* (3 * MAXNCV) */;
     float rwork[256];
 
-    complex h, s, s1, s2, s3;
-    complex sigma;
+    float h, s;
+    complex sigma, s1, s2, s3;
 
     int j;
     int ierr, nconv;
@@ -139,47 +132,24 @@ int cndrv4()
     complex* dl = (complex*)malloc(n * sizeof(complex));
     complex* du2 = (complex*)malloc(n * sizeof(complex));
 
-    convct_1.rho.r = 10.0f, convct_1.rho.i = 0.0f;
-    i__1 = n + 1;
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h.r = q__1.r, h.i = q__1.i;
-    c_div(&q__1, &convct_1.rho, &c_two);
-    s.r = q__1.r, s.i = q__1.i;
+    h = 1.0f / (float)(n + 1);
+    s = RHO / 2.0f;
 
-    q__4.r = -1.f, q__4.i = -0.0f;
-    c_div(&q__3, &q__4, &h);
-    q__2.r = q__3.r - s.r, q__2.i = q__3.i - s.i;
-    q__6.r = sigma.r * h.r - sigma.i * h.i, q__6.i = sigma.r * h.i +
-             sigma.i * h.r;
-    c_div(&q__5, &q__6, &c_six);
-    q__1.r = q__2.r - q__5.r, q__1.i = q__2.i - q__5.i;
-    s1.r = q__1.r, s1.i = q__1.i;
-    c_div(&q__2, &c_two, &h);
-    q__5.r = sigma.r * 4.0f - sigma.i * 0.0f, q__5.i = sigma.i * 4.0f + sigma.r *
-             0.0f;
-    q__4.r = q__5.r * h.r - q__5.i * h.i, q__4.i = q__5.r * h.i +
-             q__5.i * h.r;
-    c_div(&q__3, &q__4, &c_six);
-    q__1.r = q__2.r - q__3.r, q__1.i = q__2.i - q__3.i;
-    s2.r = q__1.r, s2.i = q__1.i;
-    q__4.r = -1.f, q__4.i = -0.0f;
-    c_div(&q__3, &q__4, &h);
-    q__2.r = q__3.r + s.r, q__2.i = q__3.i + s.i;
-    q__6.r = sigma.r * h.r - sigma.i * h.i, q__6.i = sigma.r * h.i +
-             sigma.i * h.r;
-    c_div(&q__5, &q__6, &c_six);
-    q__1.r = q__2.r - q__5.r, q__1.i = q__2.i - q__5.i;
-    s3.r = q__1.r, s3.i = q__1.i;
+    s1.r = (-1.0f / h - s) - sigma.r * h / 6.0f;
+    s1.i = -sigma.i * h / 6.0f;
+
+    s2.r = 2.0f / h - (sigma.r * 4.0f * h / 6.0f);
+    s2.i = -sigma.i * 4.0f * h / 6.0f;
+
+    s3.r = (-1.0f / h + s) - (sigma.r * h / 6.0f);
+    s3.i = -sigma.i * h / 6.0f;
 
     i__1 = n - 1;
     for (j = 1; j <= i__1; ++j)
     {
         i__2 = j - 1;
         dl[i__2].r = s1.r, dl[i__2].i = s1.i;
-        i__2 = j - 1;
         dd[i__2].r = s2.r, dd[i__2].i = s2.i;
-        i__2 = j - 1;
         du[i__2].r = s3.r, du[i__2].i = s3.i;
     }
     i__1 = n - 1;
@@ -460,133 +430,73 @@ EXIT:
     return ierr;
 }
 
-/* ========================================================================== */
-
-/*     matrix vector multiplication subroutine */
-
+/** Matrix vector multiplication subroutine.
+ *
+ * Compute the matrix vector multiplication y<---M*x
+ * where M is a n by n symmetric tridiagonal matrix with 4 on the
+ * diagonal, 1 on the subdiagonal and superdiagonal.
+ */
 int cndrv4_mv_(const int n, complex *v, complex *w)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    complex q__1, q__2, q__3, q__4, q__5, q__6;
-
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
     complex h;
     int j;
 
-    /*     Compute the matrix vector multiplication y<---M*x */
-    /*     where M is a n by n symmetric tridiagonal matrix with 4 on the */
-    /*     diagonal, 1 on the subdiagonal and superdiagonal. */
-
-    /* Parameter adjustments */
-    --w;
-    --v;
-
     /* Function Body */
-    q__3.r = v[1].r * 4.0f - v[1].i * 0.0f, q__3.i = v[1].i * 4.0f + v[1].r *
-             0.0f;
-    q__4.r = v[2].r * 1.0f - v[2].i * 0.0f, q__4.i = v[2].i * 1.0f + v[2].r *
-             0.0f;
-    q__2.r = q__3.r + q__4.r, q__2.i = q__3.i + q__4.i;
-    c_div(&q__1, &q__2, &c_six);
-    w[1].r = q__1.r, w[1].i = q__1.i;
+    w[0].r = (v[0].r * 4.0f + v[1].r) / 6.0f;
+    w[0].i = (v[0].i * 4.0f + v[1].i) / 6.0f;
     i__1 = n - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        q__4.r = v[i__3].r * 1.0f - v[i__3].i * 0.0f, q__4.i = v[i__3].i * 1.0f + v[i__3].r * 0.0f;
-        i__4 = j;
-        q__5.r = v[i__4].r * 4.0f - v[i__4].i * 0.0f, q__5.i = v[i__4].i * 4.0f + v[i__4].r * 0.0f;
-        q__3.r = q__4.r + q__5.r, q__3.i = q__4.i + q__5.i;
-        i__5 = j + 1;
-        q__6.r = v[i__5].r * 1.0f - v[i__5].i * 0.0f, q__6.i = v[i__5].i * 1.0f + v[i__5].r * 0.0f;
-        q__2.r = q__3.r + q__6.r, q__2.i = q__3.i + q__6.i;
-        c_div(&q__1, &q__2, &c_six);
-        w[i__2].r = q__1.r, w[i__2].i = q__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        w[j].r = (v[i__2].r + v[j].r * 4.0f + v[i__3].r) / 6.0f;
+        w[j].i = (v[i__2].i + v[j].i * 4.0f + v[i__3].i) / 6.0f;
     }
-    i__1 = n;
-    i__2 = n - 1;
-    q__3.r = v[i__2].r * 1.0f - v[i__2].i * 0.0f, q__3.i = v[i__2].i * 1.0f + v[i__2].r * 0.0f;
-    i__3 = n;
-    q__4.r = v[i__3].r * 4.0f - v[i__3].i * 0.0f, q__4.i = v[i__3].i * 4.0f + v[i__3].r * 0.0f;
-    q__2.r = q__3.r + q__4.r, q__2.i = q__3.i + q__4.i;
-    c_div(&q__1, &q__2, &c_six);
-    w[i__1].r = q__1.r, w[i__1].i = q__1.i;
+    i__1 = n - 1;
+    i__2 = n - 2;
+    w[i__1].r = (v[i__2].r + v[i__1].r * 4.0f) / 6.0f;
+    w[i__1].i = (v[i__2].i + v[i__1].i * 4.0f) / 6.0f;
 
-    i__1 = n + 1;
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h.r = q__1.r, h.i = q__1.i;
-    cscal_(&n, &h, &w[1], &c__1);
+    h.r = 1.0f / (float)(n + 1);
+    h.i = 0.0f;
+    cscal_(&n, &h, w, &c__1);
     return 0;
 } /* mv_ */
 
-/* ------------------------------------------------------------------ */
 int cndrv4_av_(const int n, complex *v, complex *w)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    complex q__1, q__2, q__3, q__4, q__5;
-
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
-    complex h;
     int j;
-    complex s, dd, dl, du;
-
-    /* Parameter adjustments */
-    --w;
-    --v;
+    float h, s, dd, dl, du;
 
     /* Function Body */
-    i__1 = n + 1;
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h.r = q__1.r, h.i = q__1.i;
-    c_div(&q__1, &convct_1.rho, &c_two);
-    s.r = q__1.r, s.i = q__1.i;
-    c_div(&q__1, &c_two, &h);
-    dd.r = q__1.r, dd.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h);
-    q__1.r = q__2.r - s.r, q__1.i = q__2.i - s.i;
-    dl.r = q__1.r, dl.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h);
-    q__1.r = q__2.r + s.r, q__1.i = q__2.i + s.i;
-    du.r = q__1.r, du.i = q__1.i;
+    h = 1.0f / (float)(n + 1);
+    s = RHO / 2.0f;
+    dd = 2.0f / h;
+    dl = -1.0f / h - s;
+    du = -1.0f / h + s;
 
-    q__2.r = dd.r * v[1].r - dd.i * v[1].i, q__2.i = dd.r * v[1].i + dd.i * v[1].r;
-    q__3.r = du.r * v[2].r - du.i * v[2].i, q__3.i = du.r * v[2].i + du.i * v[2].r;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    w[1].r = q__1.r, w[1].i = q__1.i;
+    w[0].r = dd * v[0].r + du * v[1].r;
+    w[0].i = dd * v[0].i + du * v[1].i;
+
     i__1 = n - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        q__3.r = dl.r * v[i__3].r - dl.i * v[i__3].i, q__3.i = dl.r * v[i__3].i + dl.i * v[i__3].r;
-        i__4 = j;
-        q__4.r = dd.r * v[i__4].r - dd.i * v[i__4].i, q__4.i = dd.r * v[i__4].i + dd.i * v[i__4].r;
-        q__2.r = q__3.r + q__4.r, q__2.i = q__3.i + q__4.i;
-        i__5 = j + 1;
-        q__5.r = du.r * v[i__5].r - du.i * v[i__5].i, q__5.i = du.r * v[i__5].i + du.i * v[i__5].r;
-        q__1.r = q__2.r + q__5.r, q__1.i = q__2.i + q__5.i;
-        w[i__2].r = q__1.r, w[i__2].i = q__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        w[j].r = dl * v[i__2].r + dd * v[j].r + du * v[i__3].r;
+        w[j].i = dl * v[i__2].i + dd * v[j].i + du * v[i__3].i;
     }
-    i__1 = n;
-    i__2 = n - 1;
-    q__2.r = dl.r * v[i__2].r - dl.i * v[i__2].i, q__2.i = dl.r * v[i__2].i + dl.i * v[i__2].r;
-    i__3 = n;
-    q__3.r = dd.r * v[i__3].r - dd.i * v[i__3].i, q__3.i = dd.r * v[i__3].i + dd.i * v[i__3].r;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    w[i__1].r = q__1.r, w[i__1].i = q__1.i;
+    i__1 = n - 1;
+    i__2 = n - 2;
+    w[i__1].r = dl * v[i__2].r + dd * v[i__1].r;
+    w[i__1].i = dl * v[i__2].i + dd * v[i__1].i;
     return 0;
 } /* av_ */
-

--- a/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/zndrv1.c
+++ b/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/zndrv1.c
@@ -332,149 +332,102 @@ EXIT:
     return ierr;
 }
 
-/* ========================================================================== */
-
-/*     matrix vector subroutine */
-
-/*     The matrix used is the convection-diffusion operator */
-/*     discretized using centered difference. */
-
+/** Matrix vector subroutine.
+ *
+ * The matrix used is the convection-diffusion operator
+ * discretized using centered difference.
+ * 
+ * Computes w <--- OP*v, where OP is the nx*nx by nx*nx block
+ * tridiagonal matrix
+ *
+ *              | T -I          |
+ *              |-I  T -I       |
+ *         OP = |   -I  T       |
+ *              |        ...  -I|
+ *              |           -I T|
+ *
+ * derived from the standard central difference  discretization
+ * of the 2-dimensional convection-diffusion operator
+ *              (Laplacian u) + rho*(du/dx)
+ * on the unit squqre with zero boundary condition.
+ *
+ * The subroutine TV is called to computed y<---T*x.
+ */
 int zndrv1_av_(const int nx, zomplex *v, zomplex *w)
 {
     /* System generated locals */
     int i__1;
-    zomplex z__1, z__2;
-
-    /* Builtin functions */
-    void z_div(zomplex *, zomplex *, zomplex *);
 
     /* Local variables */
     int j;
-    zomplex h2;
     int lo;
-
-    /*     Computes w <--- OP*v, where OP is the nx*nx by nx*nx block */
-    /*     tridiagonal matrix */
-
-    /*                  | T -I          | */
-    /*                  |-I  T -I       | */
-    /*             OP = |   -I  T       | */
-    /*                  |        ...  -I| */
-    /*                  |           -I T| */
-
-    /*     derived from the standard central difference  discretization */
-    /*     of the convection-diffusion operator (Laplacian u) + rho*(du/dx) */
-    /*     with zero boundary condition. */
-
-    /*     The subroutine TV is called to computed y<---T*x. */
+    double h2;
+    zomplex z;
 
     /* Parameter adjustments */
     --w;
     --v;
 
     /* Function Body */
-    i__1 = (nx + 1) * (nx + 1);
-    z__2.r = (double) i__1, z__2.i = 0.0;
-    z_div(&z__1, &z_one, &z__2);
-    h2.r = z__1.r, h2.i = z__1.i;
+    h2 = 1.0 / (double)((nx + 1) * (nx + 1));
+
+    z.r = -1.0 / h2;
+    z.i = -0.0;
 
     zndrv1_tv_(nx, &v[1], &w[1]);
-    z__2.r = -1., z__2.i = -0.0;
-    z_div(&z__1, &z__2, &h2);
-    zaxpy_(&nx, &z__1, &v[nx + 1], &c__1, &w[1], &c__1);
+    zaxpy_(&nx, &z, &v[nx + 1], &c__1, &w[1], &c__1);
 
     i__1 = nx - 1;
     for (j = 2; j <= i__1; ++j)
     {
         lo = (j - 1) * nx;
         zndrv1_tv_(nx, &v[lo + 1], &w[lo + 1]);
-        z__2.r = -1., z__2.i = -0.0;
-        z_div(&z__1, &z__2, &h2);
-        zaxpy_(&nx, &z__1, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
-        z__2.r = -1., z__2.i = -0.0;
-        z_div(&z__1, &z__2, &h2);
-        zaxpy_(&nx, &z__1, &v[lo + nx + 1], &c__1, &w[lo + 1], &c__1);
+        zaxpy_(&nx, &z, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
+        zaxpy_(&nx, &z, &v[lo + nx + 1], &c__1, &w[lo + 1], &c__1);
     }
 
     lo = (nx - 1) * nx;
     zndrv1_tv_(nx, &v[lo + 1], &w[lo + 1]);
-    z__2.r = -1., z__2.i = -0.0;
-    z_div(&z__1, &z__2, &h2);
-    zaxpy_(&nx, &z__1, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
+    zaxpy_(&nx, &z, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
 
     return 0;
 } /* av_ */
 
-/* ========================================================================= */
+/**
+ * Compute the matrix vector multiplication y<---T*x
+ * where T is a nx by nx tridiagonal matrix with DD on the
+ * diagonal, DL on the subdiagonal, and DU on the superdiagonal
+ */
 int zndrv1_tv_(const int nx, zomplex *x, zomplex *y)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    zomplex z__1, z__2, z__3, z__4, z__5;
-
-    /* Builtin functions */
-    void z_div(zomplex *, zomplex *, zomplex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
-    zomplex h;
     int j;
-    zomplex h2, dd, dl, du;
-
-    /*     Compute the matrix vector multiplication y<---T*x */
-    /*     where T is a nx by nx tridiagonal matrix with DD on the */
-    /*     diagonal, DL on the subdiagonal, and DU on the superdiagonal */
-
-    /* Parameter adjustments */
-    --y;
-    --x;
+    double h, h2, dd, dl, du;
 
     /* Function Body */
-    i__1 = nx + 1;
-    z__2.r = (double) i__1, z__2.i = 0.0;
-    z_div(&z__1, &z_one, &z__2);
-    h.r = z__1.r, h.i = z__1.i;
-    z__1.r = h.r * h.r - h.i * h.i, z__1.i = h.r * h.i + h.i * h.r;
-    h2.r = z__1.r, h2.i = z__1.i;
-    z_div(&z__1, &z_four, &h2);
-    dd.r = z__1.r, dd.i = z__1.i;
-    z__3.r = -1., z__3.i = -0.0;
-    z_div(&z__2, &z__3, &h2);
-    z__5.r = 50.0, z__5.i = 0.0;
-    z_div(&z__4, &z__5, &h);
-    z__1.r = z__2.r - z__4.r, z__1.i = z__2.i - z__4.i;
-    dl.r = z__1.r, dl.i = z__1.i;
-    z__3.r = -1., z__3.i = -0.0;
-    z_div(&z__2, &z__3, &h2);
-    z__5.r = 50.0, z__5.i = 0.0;
-    z_div(&z__4, &z__5, &h);
-    z__1.r = z__2.r + z__4.r, z__1.i = z__2.i + z__4.i;
-    du.r = z__1.r, du.i = z__1.i;
+    h = 1.0 / (double)(nx + 1);
+    h2 = h * h;
+    dd = 4.0 / h2;
+    dl = -1.0 / h2 - 50.0 / h;
+    du = -1.0 / h2 + 50.0 / h;
 
-    z__2.r = dd.r * x[1].r - dd.i * x[1].i, z__2.i = dd.r * x[1].i + dd.i * x[1].r;
-    z__3.r = du.r * x[2].r - du.i * x[2].i, z__3.i = du.r * x[2].i + du.i * x[2].r;
-    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
-    y[1].r = z__1.r, y[1].i = z__1.i;
+    y[0].r = dd * x[0].r + du * x[1].r;
+    y[0].i = dd * x[0].i + du * x[1].i;
+
     i__1 = nx - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        z__3.r = dl.r * x[i__3].r - dl.i * x[i__3].i, z__3.i = dl.r * x[i__3].i + dl.i * x[i__3].r;
-        i__4 = j;
-        z__4.r = dd.r * x[i__4].r - dd.i * x[i__4].i, z__4.i = dd.r * x[i__4].i + dd.i * x[i__4].r;
-        z__2.r = z__3.r + z__4.r, z__2.i = z__3.i + z__4.i;
-        i__5 = j + 1;
-        z__5.r = du.r * x[i__5].r - du.i * x[i__5].i, z__5.i = du.r * x[i__5].i + du.i * x[i__5].r;
-        z__1.r = z__2.r + z__5.r, z__1.i = z__2.i + z__5.i;
-        y[i__2].r = z__1.r, y[i__2].i = z__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        y[j].r = (dl * x[i__2].r + dd * x[j].r) + du * x[i__3].r;
+        y[j].i = (dl * x[i__2].i + dd * x[j].i) + du * x[i__3].i;
     }
-    i__1 = nx;
-    i__2 = nx - 1;
-    z__2.r = dl.r * x[i__2].r - dl.i * x[i__2].i, z__2.i = dl.r * x[i__2].i + dl.i * x[i__2].r;
-    i__3 = nx;
-    z__3.r = dd.r * x[i__3].r - dd.i * x[i__3].i, z__3.i = dd.r * x[i__3].i + dd.i * x[i__3].r;
-    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
-    y[i__1].r = z__1.r, y[i__1].i = z__1.i;
+    i__1 = nx - 1;
+    i__2 = nx - 2;
+    y[i__1].r = dl * x[i__2].r + dd * x[i__1].r;
+    y[i__1].i = dl * x[i__2].i + dd * x[i__1].i;
     return 0;
 } /* tv_ */
-

--- a/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/zndrv2.c
+++ b/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/zndrv2.c
@@ -3,12 +3,7 @@
 #include <stdlib.h>
 #include "arpack.h"
 
-struct
-{
-    zomplex rho;
-} convct_;
-
-#define convct_1 convct_
+#define RHO 10.0
 
 /**
  * \BeginDoc
@@ -53,9 +48,7 @@ int zndrv2()
 {
     /* System generated locals */
     int i__1, i__2;
-    zomplex z__1, z__2, z__3, z__4;
-
-    void z_div(zomplex *, zomplex *, zomplex *);
+    zomplex z__1;
 
     /* Local variables */
     zomplex d[25];
@@ -63,8 +56,8 @@ int zndrv2()
     double rd[75] /* (3 * MAXNCV) */;
     double rwork[256];
 
-    zomplex h, s, h2, s1, s2, s3;
-    zomplex sigma;
+    double h, s, h2, s1, s3;
+    zomplex s2, sigma;
 
     int j;
     int ierr, nconv;
@@ -133,39 +126,21 @@ int zndrv2()
     zomplex* dl = (zomplex*)malloc(n * sizeof(zomplex));
     zomplex* du2 = (zomplex*)malloc(n * sizeof(zomplex));
 
-    convct_1.rho.r = 10.0, convct_1.rho.i = 0.0;
-    i__1 = n + 1;
-    z__2.r = (double) i__1, z__2.i = 0.0;
-    z_div(&z__1, &z_one, &z__2);
-    h.r = z__1.r, h.i = z__1.i;
-    z__1.r = h.r * h.r - h.i * h.i, z__1.i = h.r * h.i + h.i * h.r;
-    h2.r = z__1.r, h2.i = z__1.i;
-    z_div(&z__1, &convct_1.rho, &z_two);
-    s.r = z__1.r, s.i = z__1.i;
+    h = 1.0 / (double)(n + 1);
+    h2 = h * h;
+    s = RHO / 2.0;
 
-    z__3.r = -1., z__3.i = -0.0;
-    z_div(&z__2, &z__3, &h2);
-    z_div(&z__4, &s, &h);
-    z__1.r = z__2.r - z__4.r, z__1.i = z__2.i - z__4.i;
-    s1.r = z__1.r, s1.i = z__1.i;
-    z_div(&z__2, &z_two, &h2);
-    z__1.r = z__2.r - sigma.r, z__1.i = z__2.i - sigma.i;
-    s2.r = z__1.r, s2.i = z__1.i;
-    z__3.r = -1., z__3.i = -0.0;
-    z_div(&z__2, &z__3, &h2);
-    z_div(&z__4, &s, &h);
-    z__1.r = z__2.r + z__4.r, z__1.i = z__2.i + z__4.i;
-    s3.r = z__1.r, s3.i = z__1.i;
+    s1 = -1.0 / h2 - s / h;
+    s2.r = 2.0 / h2 - sigma.r, s2.i = -sigma.i;
+    s3 = -1.0 / h2 + s / h;
 
     i__1 = n - 1;
     for (j = 1; j <= i__1; ++j)
     {
         i__2 = j - 1;
-        dl[i__2].r = s1.r, dl[i__2].i = s1.i;
-        i__2 = j - 1;
+        dl[i__2].r = s1, dl[i__2].i = 0.0;
         dd[i__2].r = s2.r, dd[i__2].i = s2.i;
-        i__2 = j - 1;
-        du[i__2].r = s3.r, du[i__2].i = s3.i;
+        du[i__2].r = s3, du[i__2].i = 0.0;
     }
     i__1 = n - 1;
     dd[i__1].r = s2.r, dd[i__1].i = s2.i;
@@ -412,75 +387,40 @@ EXIT:
     return ierr;
 }
 
-/* ------------------------------------------------------------------- */
-
-/*     matrix vector multiplication subroutine */
-
+/**
+ * Matrix vector multiplication subroutine.
+ */
 int zndrv2_av_(const int n, zomplex *v, zomplex *w)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    zomplex z__1, z__2, z__3, z__4, z__5;
-
-    /* Builtin functions */
-    void z_div(zomplex *, zomplex *, zomplex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
-    zomplex h;
     int j;
-    zomplex s, h2, dd, dl, du;
-
-    /* Parameter adjustments */
-    --w;
-    --v;
+    double h, s, h2, dd, dl, du;
 
     /* Function Body */
-    i__1 = n + 1;
-    z__2.r = (double) i__1, z__2.i = 0.0;
-    z_div(&z__1, &z_one, &z__2);
-    h.r = z__1.r, h.i = z__1.i;
-    z__1.r = h.r * h.r - h.i * h.i, z__1.i = h.r * h.i + h.i * h.r;
-    h2.r = z__1.r, h2.i = z__1.i;
-    z_div(&z__1, &convct_1.rho, &z_two);
-    s.r = z__1.r, s.i = z__1.i;
-    z_div(&z__1, &z_two, &h2);
-    dd.r = z__1.r, dd.i = z__1.i;
-    z__3.r = -1., z__3.i = -0.0;
-    z_div(&z__2, &z__3, &h2);
-    z_div(&z__4, &s, &h);
-    z__1.r = z__2.r - z__4.r, z__1.i = z__2.i - z__4.i;
-    dl.r = z__1.r, dl.i = z__1.i;
-    z__3.r = -1., z__3.i = -0.0;
-    z_div(&z__2, &z__3, &h2);
-    z_div(&z__4, &s, &h);
-    z__1.r = z__2.r + z__4.r, z__1.i = z__2.i + z__4.i;
-    du.r = z__1.r, du.i = z__1.i;
+    h = 1.0 / (double) (n + 1);
+    h2 = h * h;
+    s = RHO / 2.0;
+    dd = 2.0 / h2;
+    dl = -1.0 / h2 - s / h;
+    du = -1.0 / h2 + s / h;
 
-    z__2.r = dd.r * v[1].r - dd.i * v[1].i, z__2.i = dd.r * v[1].i + dd.i * v[1].r;
-    z__3.r = du.r * v[2].r - du.i * v[2].i, z__3.i = du.r * v[2].i + du.i * v[2].r;
-    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
-    w[1].r = z__1.r, w[1].i = z__1.i;
+    w[0].r = dd * v[0].r + du * v[1].r;
+    w[0].i = dd * v[0].i + du * v[1].i;
+
     i__1 = n - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        z__3.r = dl.r * v[i__3].r - dl.i * v[i__3].i, z__3.i = dl.r * v[i__3].i + dl.i * v[i__3].r;
-        i__4 = j;
-        z__4.r = dd.r * v[i__4].r - dd.i * v[i__4].i, z__4.i = dd.r * v[i__4].i + dd.i * v[i__4].r;
-        z__2.r = z__3.r + z__4.r, z__2.i = z__3.i + z__4.i;
-        i__5 = j + 1;
-        z__5.r = du.r * v[i__5].r - du.i * v[i__5].i, z__5.i = du.r * v[i__5].i + du.i * v[i__5].r;
-        z__1.r = z__2.r + z__5.r, z__1.i = z__2.i + z__5.i;
-        w[i__2].r = z__1.r, w[i__2].i = z__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        w[j].r = (dl * v[i__2].r + dd * v[j].r) + du * v[i__3].r;
+        w[j].i = (dl * v[i__2].i + dd * v[j].i) + du * v[i__3].i;
     }
-    i__1 = n;
-    i__2 = n - 1;
-    z__2.r = dl.r * v[i__2].r - dl.i * v[i__2].i, z__2.i = dl.r * v[i__2].i + dl.i * v[i__2].r;
-    i__3 = n;
-    z__3.r = dd.r * v[i__3].r - dd.i * v[i__3].i, z__3.i = dd.r * v[i__3].i + dd.i * v[i__3].r;
-    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
-    w[i__1].r = z__1.r, w[i__1].i = z__1.i;
+    i__1 = n - 1;
+    i__2 = n - 2;
+    w[i__1].r = dl * v[i__2].r + dd * v[i__1].r;
+    w[i__1].i = dl * v[i__2].i + dd * v[i__1].i;
     return 0;
 } /* av_ */
-

--- a/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/zndrv3.c
+++ b/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/zndrv3.c
@@ -48,8 +48,6 @@ int zndrv3()
     int i__1, i__2;
     zomplex z__1, z__2;
 
-    void z_div(zomplex *, zomplex *, zomplex *);
-
     /* Local variables */
     zomplex d[25];
     zomplex workev[50];
@@ -120,26 +118,18 @@ int zndrv3()
     zomplex* dl = (zomplex*)malloc(n * sizeof(zomplex));
     zomplex* du2 = (zomplex*)malloc(n * sizeof(zomplex));
 
-    i__1 = n + 1;
-    z__2.r = (double) i__1, z__2.i = 0.0;
-    z_div(&z__1, &z_one, &z__2);
-    h.r = z__1.r, h.i = z__1.i;
+    h.r = 1.0 / (double)(n + 1);
+    h.i = 0.0;
     i__1 = n - 1;
     for (j = 1; j <= i__1; ++j)
     {
         i__2 = j - 1;
-        z__1.r = h.r * 1.0 - h.i * 0.0, z__1.i = h.i * 1. + h.r * 0.0;
-        dl[i__2].r = z__1.r, dl[i__2].i = z__1.i;
-        i__2 = j - 1;
-        z__1.r = h.r * 4.0 - h.i * 0.0, z__1.i = h.r * 0. + h.i * 4.0;
-        dd[i__2].r = z__1.r, dd[i__2].i = z__1.i;
-        i__2 = j - 1;
-        z__1.r = h.r * 1.0 - h.i * 0.0, z__1.i = h.i * 1. + h.r * 0.0;
-        du[i__2].r = z__1.r, du[i__2].i = z__1.i;
+        dl[i__2].r = h.r * 1.0, dl[i__2].i = h.i * 1.0;
+        dd[i__2].r = h.r * 4.0, dd[i__2].i = h.i * 4.0;
+        du[i__2].r = h.r * 1.0, du[i__2].i = h.i * 1.0;
     }
     i__1 = n - 1;
-    z__1.r = h.r * 4.0 - h.i * 0.0, z__1.i = h.r * 0. + h.i * 4.0;
-    dd[i__1].r = z__1.r, dd[i__1].i = z__1.i;
+    dd[i__1].r = h.r * 4.0, dd[i__1].i = h.i * 4.0;
 
     zgttrf_(&n, dl, dd, du, du2, ipiv, &ierr);
     if (ierr != 0)
@@ -401,132 +391,79 @@ EXIT:
     return ierr;
 }
 
-/* ========================================================================== */
-
-/*     matrix vector multiplication subroutine */
-
+/** Matrix vector multiplication subroutine.
+ *
+ * Compute the matrix vector multiplication y<---A*x
+ * where A is the stiffness matrix formed by using piecewise linear
+ * elements on [0,1].
+ */
 int zndrv3_av_(const int n, zomplex *v, zomplex *w)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    zomplex z__1, z__2, z__3, z__4, z__5;
-
-    /* Builtin functions */
-    void z_div(zomplex *, zomplex *, zomplex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
-    zomplex h;
     int j;
-    zomplex s, dd, dl, du;
-
-    /*     Compute the matrix vector multiplication y<---A*x */
-    /*     where A is the stiffness matrix formed by using piecewise linear */
-    /*     elements on [0,1]. */
-
-    /* Parameter adjustments */
-    --w;
-    --v;
+    double h, s, dd, dl, du;
 
     /* Function Body */
-    i__1 = n + 1;
-    z__2.r = (double) i__1, z__2.i = 0.0;
-    z_div(&z__1, &z_one, &z__2);
-    h.r = z__1.r, h.i = z__1.i;
-    z_div(&z__1, &z_ten, &z_two);
-    s.r = z__1.r, s.i = z__1.i;
-    z_div(&z__1, &z_two, &h);
-    dd.r = z__1.r, dd.i = z__1.i;
-    z__3.r = -1., z__3.i = -0.0;
-    z_div(&z__2, &z__3, &h);
-    z__1.r = z__2.r - s.r, z__1.i = z__2.i - s.i;
-    dl.r = z__1.r, dl.i = z__1.i;
-    z__3.r = -1., z__3.i = -0.0;
-    z_div(&z__2, &z__3, &h);
-    z__1.r = z__2.r + s.r, z__1.i = z__2.i + s.i;
-    du.r = z__1.r, du.i = z__1.i;
+    h = 1.0 / (double)(n + 1);
+    s = 10.0 / 2.0;
+    dd = 2.0 / h;
+    dl = -1.0 / h - s;
+    du = -1.0 / h + s;
 
-    z__2.r = dd.r * v[1].r - dd.i * v[1].i, z__2.i = dd.r * v[1].i + dd.i * v[1].r;
-    z__3.r = du.r * v[2].r - du.i * v[2].i, z__3.i = du.r * v[2].i + du.i * v[2].r;
-    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
-    w[1].r = z__1.r, w[1].i = z__1.i;
+    w[0].r = dd * v[0].r + du * v[1].r;
+    w[0].i = dd * v[0].i + du * v[1].i;
+
     i__1 = n - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        z__3.r = dl.r * v[i__3].r - dl.i * v[i__3].i, z__3.i = dl.r * v[i__3].i + dl.i * v[i__3].r;
-        i__4 = j;
-        z__4.r = dd.r * v[i__4].r - dd.i * v[i__4].i, z__4.i = dd.r * v[i__4].i + dd.i * v[i__4].r;
-        z__2.r = z__3.r + z__4.r, z__2.i = z__3.i + z__4.i;
-        i__5 = j + 1;
-        z__5.r = du.r * v[i__5].r - du.i * v[i__5].i, z__5.i = du.r * v[i__5].i + du.i * v[i__5].r;
-        z__1.r = z__2.r + z__5.r, z__1.i = z__2.i + z__5.i;
-        w[i__2].r = z__1.r, w[i__2].i = z__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        w[j].r = (dl * v[i__2].r + dd * v[j].r) + du * v[i__3].r;
+        w[j].i = (dl * v[i__2].i + dd * v[j].i) + du * v[i__3].i;
     }
-    i__1 = n;
-    i__2 = n - 1;
-    z__2.r = dl.r * v[i__2].r - dl.i * v[i__2].i, z__2.i = dl.r * v[i__2].i + dl.i * v[i__2].r;
-    i__3 = n;
-    z__3.r = dd.r * v[i__3].r - dd.i * v[i__3].i, z__3.i = dd.r * v[i__3].i + dd.i * v[i__3].r;
-    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
-    w[i__1].r = z__1.r, w[i__1].i = z__1.i;
+    i__1 = n - 1;
+    i__2 = n - 2;
+    w[i__1].r = dl * v[i__2].r + dd * v[i__1].r;
+    w[i__1].i = dl * v[i__2].i + dd * v[i__1].i;
     return 0;
 } /* av_ */
 
-/* ------------------------------------------------------------------------ */
+/**
+ * Compute the matrix vector multiplication y<---M*x
+ * where M is the mass matrix formed by using piecewise linear elements
+ * on [0,1].
+ */
 int zndrv3_mv_(const int n, zomplex *v, zomplex *w)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    zomplex z__1, z__2, z__3, z__4, z__5;
-
-    /* Builtin functions */
-    void z_div(zomplex *, zomplex *, zomplex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
     zomplex h;
     int j;
 
-    /*     Compute the matrix vector multiplication y<---M*x */
-    /*     where M is the mass matrix formed by using piecewise linear elements */
-    /*     on [0,1]. */
-
-    /* Parameter adjustments */
-    --w;
-    --v;
-
     /* Function Body */
-    z__2.r = v[1].r * 4.0 - v[1].i * 0.0, z__2.i = v[1].i * 4.0 + v[1].r * 0.0;
-    z__3.r = v[2].r * 1.0 - v[2].i * 0.0, z__3.i = v[2].i * 1. + v[2].r * 0.0;
-    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
-    w[1].r = z__1.r, w[1].i = z__1.i;
-    i__1 = n - 1;
-    for (j = 2; j <= i__1; ++j)
-    {
-        i__2 = j;
-        i__3 = j - 1;
-        z__3.r = v[i__3].r * 1.0 - v[i__3].i * 0.0, z__3.i = v[i__3].i * 1. + v[i__3].r * 0.0;
-        i__4 = j;
-        z__4.r = v[i__4].r * 4.0 - v[i__4].i * 0.0, z__4.i = v[i__4].i * 4.0 + v[i__4].r * 0.0;
-        z__2.r = z__3.r + z__4.r, z__2.i = z__3.i + z__4.i;
-        i__5 = j + 1;
-        z__5.r = v[i__5].r * 1.0 - v[i__5].i * 0.0, z__5.i = v[i__5].i * 1. + v[i__5].r * 0.0;
-        z__1.r = z__2.r + z__5.r, z__1.i = z__2.i + z__5.i;
-        w[i__2].r = z__1.r, w[i__2].i = z__1.i;
-    }
-    i__1 = n;
-    i__2 = n - 1;
-    z__2.r = v[i__2].r * 1.0 - v[i__2].i * 0.0, z__2.i = v[i__2].i * 1. + v[i__2].r * 0.0;
-    i__3 = n;
-    z__3.r = v[i__3].r * 4.0 - v[i__3].i * 0.0, z__3.i = v[i__3].i * 4.0 + v[i__3].r * 0.0;
-    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
-    w[i__1].r = z__1.r, w[i__1].i = z__1.i;
+    w[0].r = v[0].r * 4.0 + v[1].r * 1.0;
+    w[0].i = v[0].i * 4.0 + v[1].i * 1.0;
 
-    i__1 = n + 1;
-    z__2.r = (double) i__1, z__2.i = 0.0;
-    z_div(&z__1, &z_one, &z__2);
-    h.r = z__1.r, h.i = z__1.i;
-    zscal_(&n, &h, &w[1], &c__1);
+    i__1 = n - 1;
+    for (j = 1; j < i__1; ++j)
+    {
+        i__2 = j - 1;
+        i__3 = j + 1;
+        w[j].r = (v[i__2].r * 1.0 + v[j].r * 4.0) + v[i__3].r * 1.0;
+        w[j].i = (v[i__2].i * 1.0 + v[j].i * 4.0) + v[i__3].i * 1.0;
+    }
+    i__1 = n - 1;
+    i__2 = n - 2;
+    w[i__1].r = v[i__2].r * 1.0 + v[i__1].r * 4.0;
+    w[i__1].i = v[i__2].i * 1.0 + v[i__1].i * 4.0;
+
+    h.r = 1.0 / (double)(n + 1);
+    h.i = 0.0;
+    zscal_(&n, &h, w, &c__1);
     return 0;
 } /* mv_ */
-

--- a/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/zndrv4.c
+++ b/src/ARPACK/arpack-ng/EXAMPLES/COMPLEX/zndrv4.c
@@ -3,12 +3,7 @@
 #include <stdlib.h>
 #include "arpack.h"
 
-struct
-{
-    zomplex rho;
-} convct_;
-
-#define convct_1 convct_
+#define RHO 10.0
 
 /**
  * \BeginDoc
@@ -56,9 +51,7 @@ int zndrv4()
 {
     /* System generated locals */
     int i__1, i__2;
-    zomplex z__1, z__2, z__3, z__4, z__5, z__6;
-
-    void z_div(zomplex *, zomplex *, zomplex *);
+    zomplex z__1;
 
     /* Local variables */
     zomplex d[25];
@@ -66,8 +59,8 @@ int zndrv4()
     double rd[75] /* (3 * MAXNCV) */;
     double rwork[256];
 
-    zomplex h, s, s1, s2, s3;
-    zomplex sigma;
+    double h, s;
+    zomplex sigma, s1, s2, s3;
 
     int j;
     int ierr, nconv;
@@ -119,7 +112,7 @@ int zndrv4()
     }
     char* bmat = "G";
     char* which = "LM";
-    sigma.r = 1., sigma.i = 0.0;
+    sigma.r = 1.0, sigma.i = 0.0;
 
     /* ------------------------------------------------ */
     /* Construct C = A - SIGMA*M in COMPLEX arithmetic. */
@@ -139,47 +132,24 @@ int zndrv4()
     zomplex* dl = (zomplex*)malloc(n * sizeof(zomplex));
     zomplex* du2 = (zomplex*)malloc(n * sizeof(zomplex));
 
-    convct_1.rho.r = 10.0, convct_1.rho.i = 0.0;
-    i__1 = n + 1;
-    z__2.r = (double) i__1, z__2.i = 0.0;
-    z_div(&z__1, &z_one, &z__2);
-    h.r = z__1.r, h.i = z__1.i;
-    z_div(&z__1, &convct_1.rho, &z_two);
-    s.r = z__1.r, s.i = z__1.i;
+    h = 1.0 / (double)(n + 1);
+    s = RHO / 2.0;
 
-    z__4.r = -1., z__4.i = -0.0;
-    z_div(&z__3, &z__4, &h);
-    z__2.r = z__3.r - s.r, z__2.i = z__3.i - s.i;
-    z__6.r = sigma.r * h.r - sigma.i * h.i, z__6.i = sigma.r * h.i +
-             sigma.i * h.r;
-    z_div(&z__5, &z__6, &z_six);
-    z__1.r = z__2.r - z__5.r, z__1.i = z__2.i - z__5.i;
-    s1.r = z__1.r, s1.i = z__1.i;
-    z_div(&z__2, &z_two, &h);
-    z__5.r = sigma.r * 4.0 - sigma.i * 0.0, z__5.i = sigma.i * 4.0 + sigma.r *
-             0.0;
-    z__4.r = z__5.r * h.r - z__5.i * h.i, z__4.i = z__5.r * h.i +
-             z__5.i * h.r;
-    z_div(&z__3, &z__4, &z_six);
-    z__1.r = z__2.r - z__3.r, z__1.i = z__2.i - z__3.i;
-    s2.r = z__1.r, s2.i = z__1.i;
-    z__4.r = -1., z__4.i = -0.0;
-    z_div(&z__3, &z__4, &h);
-    z__2.r = z__3.r + s.r, z__2.i = z__3.i + s.i;
-    z__6.r = sigma.r * h.r - sigma.i * h.i, z__6.i = sigma.r * h.i +
-             sigma.i * h.r;
-    z_div(&z__5, &z__6, &z_six);
-    z__1.r = z__2.r - z__5.r, z__1.i = z__2.i - z__5.i;
-    s3.r = z__1.r, s3.i = z__1.i;
+    s1.r = (-1.0 / h - s) - sigma.r * h / 6.0;
+    s1.i = -sigma.i * h / 6.0;
+
+    s2.r = 2.0 / h - (sigma.r * 4.0 * h / 6.0);
+    s2.i = -sigma.i * 4.0 * h / 6.0;
+
+    s3.r = (-1.0 / h + s) - (sigma.r * h / 6.0);
+    s3.i = -sigma.i * h / 6.0;
 
     i__1 = n - 1;
     for (j = 1; j <= i__1; ++j)
     {
         i__2 = j - 1;
         dl[i__2].r = s1.r, dl[i__2].i = s1.i;
-        i__2 = j - 1;
         dd[i__2].r = s2.r, dd[i__2].i = s2.i;
-        i__2 = j - 1;
         du[i__2].r = s3.r, du[i__2].i = s3.i;
     }
     i__1 = n - 1;
@@ -460,131 +430,73 @@ EXIT:
     return ierr;
 }
 
-/* ========================================================================== */
-
-/*     matrix vector multiplication subroutine */
-
+/** Matrix vector multiplication subroutine.
+ *
+ * Compute the matrix vector multiplication y<---M*x
+ * where M is a n by n symmetric tridiagonal matrix with 4 on the
+ * diagonal, 1 on the subdiagonal and superdiagonal.
+ */
 int zndrv4_mv_(const int n, zomplex *v, zomplex *w)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    zomplex z__1, z__2, z__3, z__4, z__5, z__6;
-
-    /* Builtin functions */
-    void z_div(zomplex *, zomplex *, zomplex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
     zomplex h;
     int j;
 
-    /*     Compute the matrix vector multiplication y<---M*x */
-    /*     where M is a n by n symmetric tridiagonal matrix with 4 on the */
-    /*     diagonal, 1 on the subdiagonal and superdiagonal. */
-
-    /* Parameter adjustments */
-    --w;
-    --v;
-
     /* Function Body */
-    z__3.r = v[1].r * 4.0 - v[1].i * 0.0, z__3.i = v[1].i * 4.0 + v[1].r * 0.0;
-    z__4.r = v[2].r * 1.0 - v[2].i * 0.0, z__4.i = v[2].i * 1. + v[2].r * 0.0;
-    z__2.r = z__3.r + z__4.r, z__2.i = z__3.i + z__4.i;
-    z_div(&z__1, &z__2, &z_six);
-    w[1].r = z__1.r, w[1].i = z__1.i;
+    w[0].r = (v[0].r * 4.0 + v[1].r) / 6.0;
+    w[0].i = (v[0].i * 4.0 + v[1].i) / 6.0;
     i__1 = n - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        z__4.r = v[i__3].r * 1.0 - v[i__3].i * 0.0, z__4.i = v[i__3].i * 1. + v[i__3].r * 0.0;
-        i__4 = j;
-        z__5.r = v[i__4].r * 4.0 - v[i__4].i * 0.0, z__5.i = v[i__4].i * 4.0 + v[i__4].r * 0.0;
-        z__3.r = z__4.r + z__5.r, z__3.i = z__4.i + z__5.i;
-        i__5 = j + 1;
-        z__6.r = v[i__5].r * 1.0 - v[i__5].i * 0.0, z__6.i = v[i__5].i * 1. + v[i__5].r * 0.0;
-        z__2.r = z__3.r + z__6.r, z__2.i = z__3.i + z__6.i;
-        z_div(&z__1, &z__2, &z_six);
-        w[i__2].r = z__1.r, w[i__2].i = z__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        w[j].r = (v[i__2].r + v[j].r * 4.0 + v[i__3].r) / 6.0;
+        w[j].i = (v[i__2].i + v[j].i * 4.0 + v[i__3].i) / 6.0;
     }
-    i__1 = n;
-    i__2 = n - 1;
-    z__3.r = v[i__2].r * 1.0 - v[i__2].i * 0.0, z__3.i = v[i__2].i * 1. + v[i__2].r * 0.0;
-    i__3 = n;
-    z__4.r = v[i__3].r * 4.0 - v[i__3].i * 0.0, z__4.i = v[i__3].i * 4.0 + v[i__3].r * 0.0;
-    z__2.r = z__3.r + z__4.r, z__2.i = z__3.i + z__4.i;
-    z_div(&z__1, &z__2, &z_six);
-    w[i__1].r = z__1.r, w[i__1].i = z__1.i;
+    i__1 = n - 1;
+    i__2 = n - 2;
+    w[i__1].r = (v[i__2].r + v[i__1].r * 4.0) / 6.0;
+    w[i__1].i = (v[i__2].i + v[i__1].i * 4.0) / 6.0;
 
-    i__1 = n + 1;
-    z__2.r = (double) i__1, z__2.i = 0.0;
-    z_div(&z__1, &z_one, &z__2);
-    h.r = z__1.r, h.i = z__1.i;
-    zscal_(&n, &h, &w[1], &c__1);
+    h.r = 1.0 / (double)(n + 1);
+    h.i = 0.0;
+    zscal_(&n, &h, w, &c__1);
     return 0;
 } /* mv_ */
 
-/* ------------------------------------------------------------------ */
 int zndrv4_av_(const int n, zomplex *v, zomplex *w)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    zomplex z__1, z__2, z__3, z__4, z__5;
-
-    /* Builtin functions */
-    void z_div(zomplex *, zomplex *, zomplex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
-    zomplex h;
     int j;
-    zomplex s, dd, dl, du;
-
-    /* Parameter adjustments */
-    --w;
-    --v;
+    double h, s, dd, dl, du;
 
     /* Function Body */
-    i__1 = n + 1;
-    z__2.r = (double) i__1, z__2.i = 0.0;
-    z_div(&z__1, &z_one, &z__2);
-    h.r = z__1.r, h.i = z__1.i;
-    z_div(&z__1, &convct_1.rho, &z_two);
-    s.r = z__1.r, s.i = z__1.i;
-    z_div(&z__1, &z_two, &h);
-    dd.r = z__1.r, dd.i = z__1.i;
-    z__3.r = -1., z__3.i = -0.0;
-    z_div(&z__2, &z__3, &h);
-    z__1.r = z__2.r - s.r, z__1.i = z__2.i - s.i;
-    dl.r = z__1.r, dl.i = z__1.i;
-    z__3.r = -1., z__3.i = -0.0;
-    z_div(&z__2, &z__3, &h);
-    z__1.r = z__2.r + s.r, z__1.i = z__2.i + s.i;
-    du.r = z__1.r, du.i = z__1.i;
+    h = 1.0 / (double)(n + 1);
+    s = RHO / 2.0;
+    dd = 2.0 / h;
+    dl = -1.0 / h - s;
+    du = -1.0 / h + s;
 
-    z__2.r = dd.r * v[1].r - dd.i * v[1].i, z__2.i = dd.r * v[1].i + dd.i * v[1].r;
-    z__3.r = du.r * v[2].r - du.i * v[2].i, z__3.i = du.r * v[2].i + du.i * v[2].r;
-    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
-    w[1].r = z__1.r, w[1].i = z__1.i;
+    w[0].r = dd * v[0].r + du * v[1].r;
+    w[0].i = dd * v[0].i + du * v[1].i;
+
     i__1 = n - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        z__3.r = dl.r * v[i__3].r - dl.i * v[i__3].i, z__3.i = dl.r * v[i__3].i + dl.i * v[i__3].r;
-        i__4 = j;
-        z__4.r = dd.r * v[i__4].r - dd.i * v[i__4].i, z__4.i = dd.r * v[i__4].i + dd.i * v[i__4].r;
-        z__2.r = z__3.r + z__4.r, z__2.i = z__3.i + z__4.i;
-        i__5 = j + 1;
-        z__5.r = du.r * v[i__5].r - du.i * v[i__5].i, z__5.i = du.r * v[i__5].i + du.i * v[i__5].r;
-        z__1.r = z__2.r + z__5.r, z__1.i = z__2.i + z__5.i;
-        w[i__2].r = z__1.r, w[i__2].i = z__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        w[j].r = dl * v[i__2].r + dd * v[j].r + du * v[i__3].r;
+        w[j].i = dl * v[i__2].i + dd * v[j].i + du * v[i__3].i;
     }
-    i__1 = n;
-    i__2 = n - 1;
-    z__2.r = dl.r * v[i__2].r - dl.i * v[i__2].i, z__2.i = dl.r * v[i__2].i + dl.i * v[i__2].r;
-    i__3 = n;
-    z__3.r = dd.r * v[i__3].r - dd.i * v[i__3].i, z__3.i = dd.r * v[i__3].i + dd.i * v[i__3].r;
-    z__1.r = z__2.r + z__3.r, z__1.i = z__2.i + z__3.i;
-    w[i__1].r = z__1.r, w[i__1].i = z__1.i;
+    i__1 = n - 1;
+    i__2 = n - 2;
+    w[i__1].r = dl * v[i__2].r + dd * v[i__1].r;
+    w[i__1].i = dl * v[i__2].i + dd * v[i__1].i;
     return 0;
 } /* av_ */
-

--- a/src/ARPACK/arpack-ng/EXAMPLES/SIMPLE/cnsimp.c
+++ b/src/ARPACK/arpack-ng/EXAMPLES/SIMPLE/cnsimp.c
@@ -450,150 +450,103 @@ EXIT:
     return ierr;
 }
 
-/* ========================================================================== */
-
-/*     matrix vector subroutine */
-
-/*     The matrix used is the convection-diffusion operator */
-/*     discretized using centered difference. */
-
+/** Matrix vector subroutine.
+ *
+ * The matrix used is the convection-diffusion operator
+ * discretized using centered difference.
+ *
+ * Computes w <--- OP*v, where OP is the nx*nx by nx*nx block
+ * tridiagonal matrix
+ *
+ *                  | T -I          |
+ *                  |-I  T -I       |
+ *             OP = |   -I  T       |
+ *                  |        ...  -I|
+ *                  |           -I T|
+ *
+ * derived from the standard central difference discretization
+ * of the 2-dimensional convection-diffusion operator
+ *              (Laplacian u) + rho*(du/dx)
+ * on the unit squqre with zero boundary condition.
+ *
+ * The subroutine TV is called to computed y<---T*x.
+ */
 int cnsimp_av_(const int nx, complex *v, complex *w)
 {
     /* System generated locals */
     int i__1;
-    complex q__1, q__2;
-
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *);
 
     /* Local variables */
     int j;
-    complex h2;
     int lo;
-
-    /*     Computes w <--- OP*v, where OP is the nx*nx by nx*nx block */
-    /*     tridiagonal matrix */
-
-    /*                  | T -I          | */
-    /*                  |-I  T -I       | */
-    /*             OP = |   -I  T       | */
-    /*                  |        ...  -I| */
-    /*                  |           -I T| */
-
-    /*     derived from the standard central difference discretization */
-    /*     of the 2-dimensional convection-diffusion operator */
-    /*                  (Laplacian u) + rho*(du/dx) */
-    /*     on the unit squqre with zero boundary condition. */
-
-    /*     The subroutine TV is called to computed y<---T*x. */
+    float h2;
+    complex z;
 
     /* Parameter adjustments */
     --w;
     --v;
 
     /* Function Body */
-    i__1 = (nx + 1) * (nx + 1);
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h2.r = q__1.r, h2.i = q__1.i;
+    h2 = 1.0f / (float)((nx + 1) * (nx + 1));
+
+    z.r = -1.0f / h2;
+    z.i = -0.0f;
 
     cnsimp_tv_(nx, &v[1], &w[1]);
-    q__2.r = -1.f, q__2.i = -0.0f;
-    c_div(&q__1, &q__2, &h2);
-    caxpy_(&nx, &q__1, &v[nx + 1], &c__1, &w[1], &c__1);
+    caxpy_(&nx, &z, &v[nx + 1], &c__1, &w[1], &c__1);
 
     i__1 = nx - 1;
     for (j = 2; j <= i__1; ++j)
     {
         lo = (j - 1) * nx;
         cnsimp_tv_(nx, &v[lo + 1], &w[lo + 1]);
-        q__2.r = -1.f, q__2.i = -0.0f;
-        c_div(&q__1, &q__2, &h2);
-        caxpy_(&nx, &q__1, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
-        q__2.r = -1.f, q__2.i = -0.0f;
-        c_div(&q__1, &q__2, &h2);
-        caxpy_(&nx, &q__1, &v[lo + nx + 1], &c__1, &w[lo + 1], &c__1);
+        caxpy_(&nx, &z, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
+        caxpy_(&nx, &z, &v[lo + nx + 1], &c__1, &w[lo + 1], &c__1);
     }
 
     lo = (nx - 1) * nx;
     cnsimp_tv_(nx, &v[lo + 1], &w[lo + 1]);
-    q__2.r = -1.f, q__2.i = -0.0f;
-    c_div(&q__1, &q__2, &h2);
-    caxpy_(&nx, &q__1, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
+    caxpy_(&nx, &z, &v[lo - nx + 1], &c__1, &w[lo + 1], &c__1);
 
     return 0;
 } /* av_ */
 
-/* ========================================================================= */
+/**
+ * Compute the matrix vector multiplication y<---T*x
+ * where T is a nx by nx tridiagonal matrix with DD on the
+ * diagonal, DL on the subdiagonal, and DU on the superdiagonal
+ */
 int cnsimp_tv_(const int nx, complex *x, complex *y)
 {
     /* System generated locals */
-    int i__1, i__2, i__3, i__4, i__5;
-    complex q__1, q__2, q__3, q__4, q__5;
-
-    /* Builtin functions */
-    void c_div(complex *, complex *, complex *);
+    int i__1, i__2, i__3;
 
     /* Local variables */
-    complex h;
     int j;
-    complex h2, dd, dl, du;
-
-    /*     Compute the matrix vector multiplication y<---T*x */
-    /*     where T is a nx by nx tridiagonal matrix with DD on the */
-    /*     diagonal, DL on the subdiagonal, and DU on the superdiagonal */
-
-    /* Parameter adjustments */
-    --y;
-    --x;
+    float h, h2, dd, dl, du;
 
     /* Function Body */
-    i__1 = nx + 1;
-    q__2.r = (float) i__1, q__2.i = 0.0f;
-    c_div(&q__1, &c_one, &q__2);
-    h.r = q__1.r, h.i = q__1.i;
-    q__1.r = h.r * h.r - h.i * h.i, q__1.i = h.r * h.i + h.i * h.r;
-    h2.r = q__1.r, h2.i = q__1.i;
-    c_div(&q__1, &c_four, &h2);
-    dd.r = q__1.r, dd.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h2);
-    q__5.r = 50.0f, q__5.i = 0.0f;
-    c_div(&q__4, &q__5, &h);
-    q__1.r = q__2.r - q__4.r, q__1.i = q__2.i - q__4.i;
-    dl.r = q__1.r, dl.i = q__1.i;
-    q__3.r = -1.f, q__3.i = -0.0f;
-    c_div(&q__2, &q__3, &h2);
-    q__5.r = 50.0f, q__5.i = 0.0f;
-    c_div(&q__4, &q__5, &h);
-    q__1.r = q__2.r + q__4.r, q__1.i = q__2.i + q__4.i;
-    du.r = q__1.r, du.i = q__1.i;
+    h = 1.0f / (float)(nx + 1);
+    h2 = h * h;
+    dd = 4.0f / h2;
+    dl = -1.0f / h2 - 50.0f / h;
+    du = -1.0f / h2 + 50.0f / h;
 
-    q__2.r = dd.r * x[1].r - dd.i * x[1].i, q__2.i = dd.r * x[1].i + dd.i * x[1].r;
-    q__3.r = du.r * x[2].r - du.i * x[2].i, q__3.i = du.r * x[2].i + du.i * x[2].r;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    y[1].r = q__1.r, y[1].i = q__1.i;
+    y[0].r = dd * x[0].r + du * x[1].r;
+    y[0].i = dd * x[0].i + du * x[1].i;
+
     i__1 = nx - 1;
-    for (j = 2; j <= i__1; ++j)
+    for (j = 1; j < i__1; ++j)
     {
-        i__2 = j;
-        i__3 = j - 1;
-        q__3.r = dl.r * x[i__3].r - dl.i * x[i__3].i, q__3.i = dl.r * x[i__3].i + dl.i * x[i__3].r;
-        i__4 = j;
-        q__4.r = dd.r * x[i__4].r - dd.i * x[i__4].i, q__4.i = dd.r * x[i__4].i + dd.i * x[i__4].r;
-        q__2.r = q__3.r + q__4.r, q__2.i = q__3.i + q__4.i;
-        i__5 = j + 1;
-        q__5.r = du.r * x[i__5].r - du.i * x[i__5].i, q__5.i = du.r * x[i__5].i + du.i * x[i__5].r;
-        q__1.r = q__2.r + q__5.r, q__1.i = q__2.i + q__5.i;
-        y[i__2].r = q__1.r, y[i__2].i = q__1.i;
+        i__2 = j - 1;
+        i__3 = j + 1;
+        y[j].r = (dl * x[i__2].r + dd * x[j].r) + du * x[i__3].r;
+        y[j].i = (dl * x[i__2].i + dd * x[j].i) + du * x[i__3].i;
     }
-    i__1 = nx;
-    i__2 = nx - 1;
-    q__2.r = dl.r * x[i__2].r - dl.i * x[i__2].i, q__2.i = dl.r * x[i__2].i + dl.i * x[i__2].r;
-    i__3 = nx;
-    q__3.r = dd.r * x[i__3].r - dd.i * x[i__3].i, q__3.i = dd.r * x[i__3].i + dd.i * x[i__3].r;
-    q__1.r = q__2.r + q__3.r, q__1.i = q__2.i + q__3.i;
-    y[i__1].r = q__1.r, y[i__1].i = q__1.i;
+    i__1 = nx - 1;
+    i__2 = nx - 2;
+    y[i__1].r = dl * x[i__2].r + dd * x[i__1].r;
+    y[i__1].i = dl * x[i__2].i + dd * x[i__1].i;
     return 0;
 } /* tv_ */
 

--- a/src/ARPACK/arpack-ng/SRC/cgetv0.c
+++ b/src/ARPACK/arpack-ng/SRC/cgetv0.c
@@ -122,7 +122,7 @@ int cgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     static bool inits = true;
 
     /* System generated locals */
-    int v_offset, i__1;
+    int i__1;
     float r__1, r__2;
     complex q__1;
 
@@ -140,13 +140,6 @@ int cgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     static bool first;
     static float rnorm0;
     static int msglvl;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    --ipntr;
 
     /* Function Body */
 
@@ -195,7 +188,7 @@ int cgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (! (*initv))
         {
             idist = 2;
-            clarnv_(&idist, iseed, n, &resid[1]);
+            clarnv_(&idist, iseed, n, resid);
         }
 
         /* -------------------------------------------------------- */
@@ -210,15 +203,16 @@ int cgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (*itry == 1)
         {
             ++timing_1.nopx;
-            ipntr[1] = 1;
-            ipntr[2] = *n + 1;
-            ccopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+            /* TODO: subtract 1 */
+            ipntr[0] = 1;
+            ipntr[1] = *n + 1;
+            ccopy_(n, resid, &c__1, workd, &c__1);
             *ido = -1;
             goto L9000;
         }
         else if (*itry > 1 && *bmat == 'G')
         {
-            ccopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
+            ccopy_(n, resid, &c__1, &workd[*n], &c__1);
         }
     }
 
@@ -257,19 +251,20 @@ int cgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     first = true;
     if (*itry == 1)
     {
-        ccopy_(n, &workd[*n + 1], &c__1, &resid[1], &c__1);
+        ccopy_(n, &workd[*n], &c__1, resid, &c__1);
     }
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
         goto L9000;
     }
     else if (*bmat == 'I')
     {
-        ccopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        ccopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L20:
@@ -281,7 +276,7 @@ L20:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        cdotc_(&q__1, n, &resid[1], &c__1, &workd[1], &c__1);
+        cdotc_(&q__1, n, resid, &c__1, workd, &c__1);
         cnorm.r = q__1.r, cnorm.i = q__1.i;
         r__1 = cnorm.r;
         r__2 = cnorm.i;
@@ -289,7 +284,7 @@ L20:
     }
     else if (*bmat == 'I')
     {
-        rnorm0 = scnrm2_(n, &resid[1], &c__1);
+        rnorm0 = scnrm2_(n, resid, &c__1);
     }
     *rnorm = rnorm0;
 
@@ -318,9 +313,9 @@ L20:
 L30:
 
     i__1 = *j - 1;
-    cgemv_("C", n, &i__1, &c_one, &v[v_offset], ldv, &workd[1], &c__1, &c_zero, &workd[*n + 1], &c__1);
+    cgemv_("C", n, &i__1, &c_one, v, ldv, workd, &c__1, &c_zero, &workd[*n], &c__1);
     q__1.r = -1.f, q__1.i = -0.0f;
-    cgemv_("N", n, &i__1, &q__1, &v[v_offset], ldv, &workd[*n + 1], &c__1, &c_one, &resid[1], &c__1);
+    cgemv_("N", n, &i__1, &q__1, v, ldv, &workd[*n], &c__1, &c_one, resid, &c__1);
 
     /* -------------------------------------------------------- */
     /* Compute the B-norm of the orthogonalized starting vector */
@@ -333,15 +328,16 @@ L30:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        ccopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        ccopy_(n, resid, &c__1, &workd[*n], &c__1);
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
         goto L9000;
     }
     else if (*bmat == 'I')
     {
-        ccopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        ccopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L40:
@@ -356,7 +352,7 @@ L40:
 
     if (*bmat == 'G')
     {
-        cdotc_(&q__1, n, &resid[1], &c__1, &workd[1], &c__1);
+        cdotc_(&q__1, n, resid, &c__1, workd, &c__1);
         cnorm.r = q__1.r, cnorm.i = q__1.i;
         r__1 = cnorm.r;
         r__2 = cnorm.i;
@@ -364,7 +360,7 @@ L40:
     }
     else if (*bmat == 'I')
     {
-        *rnorm = scnrm2_(n, &resid[1], &c__1);
+        *rnorm = scnrm2_(n, resid, &c__1);
     }
 
     /* ------------------------------------ */
@@ -401,7 +397,7 @@ L40:
         /* ---------------------------------- */
 
         i__1 = *n;
-        for (jj = 1; jj <= i__1; ++jj)
+        for (jj = 0; jj < i__1; ++jj)
         {
             resid[jj].r = 0.0f, resid[jj].i = 0.0f;
         }
@@ -419,7 +415,7 @@ L50:
 
     if (msglvl > 2)
     {
-        cvout_(n, &resid[1], &debug_1.ndigit, "_getv0: initial / restarted starting vector");
+        cvout_(n, resid, &debug_1.ndigit, "_getv0: initial / restarted starting vector");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/cgetv0.c
+++ b/src/ARPACK/arpack-ng/SRC/cgetv0.c
@@ -203,7 +203,7 @@ int cgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (*itry == 1)
         {
             ++timing_1.nopx;
-            /* TODO: subtract 1 */
+            /* TODO: ipntr index */
             ipntr[0] = 1;
             ipntr[1] = *n + 1;
             ccopy_(n, resid, &c__1, workd, &c__1);
@@ -256,7 +256,7 @@ int cgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;
@@ -329,7 +329,7 @@ L30:
     {
         ++timing_1.nbx;
         ccopy_(n, resid, &c__1, &workd[*n], &c__1);
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;

--- a/src/ARPACK/arpack-ng/SRC/cnaitr.c
+++ b/src/ARPACK/arpack-ng/SRC/cnaitr.c
@@ -250,14 +250,12 @@ int cnaitr_(int *ido, char *bmat, int *n, int *k,int *np, int *nb,
 
     /* Parameter adjustments */
     --workd;
-    --resid;
     v_dim = *ldv;
     v_offset = 1 + v_dim;
     v -= v_offset;
     h_dim = *ldh;
     h_offset = 1 + h_dim;
     h -= h_offset;
-    --ipntr;
 
     /* Function Body */
 
@@ -404,7 +402,7 @@ L30:
     /* RSTART = .true. flow returns here.   */
     /* ------------------------------------ */
 
-    cgetv0_(ido, bmat, &itry, &c_false, n, &j, &v[v_offset], ldv, &resid[1], rnorm, &ipntr[1], &workd[1], &ierr);
+    cgetv0_(ido, bmat, &itry, &c_false, n, &j, &v[v_offset], ldv, resid, rnorm, ipntr, &workd[1], &ierr);
     if (*ido != 99)
     {
         goto L9000;
@@ -442,7 +440,7 @@ L40:
     /* machine bound.                                          */
     /* ------------------------------------------------------- */
 
-    ccopy_(n, &resid[1], &c__1, &v[j * v_dim + 1], &c__1);
+    ccopy_(n, resid, &c__1, &v[j * v_dim + 1], &c__1);
     if (*rnorm >= unfl)
     {
         temp1 = 1.0f / *rnorm;
@@ -472,9 +470,9 @@ L40:
 #endif
 
     ccopy_(n, &v[j * v_dim + 1], &c__1, &workd[ivj], &c__1);
-    ipntr[1] = ivj;
-    ipntr[2] = irj;
-    ipntr[3] = ipj;
+    ipntr[0] = ivj;
+    ipntr[1] = irj;
+    ipntr[2] = ipj;
     *ido = 1;
 
     /* --------------------------------- */
@@ -501,7 +499,7 @@ L50:
     /* Put another copy of OP*v_{j} into RESID. */
     /* ---------------------------------------- */
 
-    ccopy_(n, &workd[irj], &c__1, &resid[1], &c__1);
+    ccopy_(n, &workd[irj], &c__1, resid, &c__1);
 
     /* ------------------------------------- */
     /* STEP 4:  Finish extending the Arnoldi */
@@ -516,8 +514,8 @@ L50:
     {
         ++timing_1.nbx;
         step4 = true;
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* ----------------------------------- */
@@ -528,7 +526,7 @@ L50:
     }
     else if (*bmat == 'I')
     {
-        ccopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        ccopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L60:
 
@@ -555,13 +553,13 @@ L60:
 
     if (*bmat == 'G')
     {
-        cdotc_(&q__1, n, &resid[1], &c__1, &workd[ipj], &c__1);
+        cdotc_(&q__1, n, resid, &c__1, &workd[ipj], &c__1);
         cnorm.r = q__1.r, cnorm.i = q__1.i;
         wnorm = sqrt(slapy2_(&cnorm.r, &cnorm.i));
     }
     else if (*bmat == 'I')
     {
-        wnorm = scnrm2_(n, &resid[1], &c__1);
+        wnorm = scnrm2_(n, resid, &c__1);
     }
 
     /* --------------------------------------- */
@@ -584,14 +582,14 @@ L60:
     /* RESID contains OP*v_{j}. See STEP 3. */
     /* ------------------------------------ */
 
-    q__1.r = -1.f, q__1.i = -0.0f;
-    cgemv_("N", n, &j, &q__1, &v[v_offset], ldv, &h[j * h_dim + 1], &c__1, &c_one, &resid[1], &c__1);
+    q__1.r = -1.0f, q__1.i = -0.0f;
+    cgemv_("N", n, &j, &q__1, &v[v_offset], ldv, &h[j * h_dim + 1], &c__1, &c_one, resid, &c__1);
 
     if (j > 1)
     {
         i__1 = j + (j - 1) * h_dim;
-        q__1.r = betaj, q__1.i = 0.0f;
-        h[i__1].r = q__1.r, h[i__1].i = q__1.i;
+        h[i__1].r = betaj;
+        h[i__1].i = 0.0f;
     }
 
 #ifndef NO_TIMER
@@ -604,9 +602,9 @@ L60:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        ccopy_(n, &resid[1], &c__1, &workd[irj], &c__1);
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        ccopy_(n, resid, &c__1, &workd[irj], &c__1);
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* -------------------------------- */
@@ -617,7 +615,7 @@ L60:
     }
     else if (*bmat == 'I')
     {
-        ccopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        ccopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L70:
 
@@ -642,13 +640,13 @@ L70:
 
     if (*bmat == 'G')
     {
-        cdotc_(&q__1, n, &resid[1], &c__1, &workd[ipj], &c__1);
+        cdotc_(&q__1, n, resid, &c__1, &workd[ipj], &c__1);
         cnorm.r = q__1.r, cnorm.i = q__1.i;
         *rnorm = sqrt(slapy2_(&cnorm.r, &cnorm.i));
     }
     else if (*bmat == 'I')
     {
-        *rnorm = scnrm2_(n, &resid[1], &c__1);
+        *rnorm = scnrm2_(n, resid, &c__1);
     }
 
     /* --------------------------------------------------------- */
@@ -711,7 +709,7 @@ L80:
     /* ------------------------------------------- */
 
     q__1.r = -1.f, q__1.i = -0.0f;
-    cgemv_("N", n, &j, &q__1, &v[v_offset], ldv, &workd[irj], &c__1, &c_one, &resid[1], &c__1);
+    cgemv_("N", n, &j, &q__1, &v[v_offset], ldv, &workd[irj], &c__1, &c_one, resid, &c__1);
     caxpy_(&j, &c_one, &workd[irj], &c__1, &h[j * h_dim + 1], &c__1);
 
     orth2 = true;
@@ -722,9 +720,9 @@ L80:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        ccopy_(n, &resid[1], &c__1, &workd[irj], &c__1);
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        ccopy_(n, resid, &c__1, &workd[irj], &c__1);
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* --------------------------------- */
@@ -736,7 +734,7 @@ L80:
     }
     else if (*bmat == 'I')
     {
-        ccopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        ccopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L90:
 
@@ -754,13 +752,13 @@ L90:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        cdotc_(&q__1, n, &resid[1], &c__1, &workd[ipj], &c__1);
+        cdotc_(&q__1, n, resid, &c__1, &workd[ipj], &c__1);
         cnorm.r = q__1.r, cnorm.i = q__1.i;
         rnorm1 = sqrt(slapy2_(&cnorm.r, &cnorm.i));
     }
     else if (*bmat == 'I')
     {
-        rnorm1 = scnrm2_(n, &resid[1], &c__1);
+        rnorm1 = scnrm2_(n, resid, &c__1);
     }
 
 #ifndef NO_TRACE
@@ -815,7 +813,7 @@ L90:
         /* ----------------------------------------------- */
 
         i__1 = *n;
-        for (jj = 1; jj <= i__1; ++jj)
+        for (jj = 0; jj < i__1; ++jj)
         {
             resid[jj].r = 0.0f, resid[jj].i = 0.0f;
         }

--- a/src/ARPACK/arpack-ng/SRC/cnapps.c
+++ b/src/ARPACK/arpack-ng/SRC/cnapps.c
@@ -166,10 +166,6 @@ int cnapps_(int *n, int *kev, int *np, complex *
     static float smlnum;
 
     /* Parameter adjustments */
-    --workd;
-    --resid;
-    --workl;
-    --shift;
     v_dim = *ldv;
     v_offset = 1 + v_dim;
     v -= v_offset;
@@ -238,7 +234,8 @@ int cnapps_(int *n, int *kev, int *np, complex *
     i__1 = *np;
     for (jj = 1; jj <= i__1; ++jj)
     {
-        sigma.r = shift[jj].r, sigma.i = shift[jj].i;
+        /* TODO: fix jj - 1 */
+        sigma.r = shift[jj - 1].r, sigma.i = shift[jj - 1].i;
 
 #ifndef NO_TRACE
         if (msglvl > 2)
@@ -270,7 +267,7 @@ L20:
             if (tst1 == 0.0f)
             {
                 i__3 = kplusp - jj + 1;
-                tst1 = clanhs_("1", &i__3, &h[h_offset], ldh, &workl[1]);
+                tst1 = clanhs_("1", &i__3, &h[h_offset], ldh, workl);
             }
             i__3 = i + 1 + i * h_dim;
             /* Computing MAX */
@@ -505,7 +502,7 @@ L100:
         tst1 = dabs(r__1) + dabs(r__2) + dabs(r__3) + dabs(r__4);
         if (tst1 == 0.0f)
         {
-            tst1 = clanhs_("1", kev, &h[h_offset], ldh, &workl[1]);
+            tst1 = clanhs_("1", kev, &h[h_offset], ldh, workl);
         }
         i__2 = i + 1 + i * h_dim;
         /* Computing MAX */
@@ -527,7 +524,7 @@ L100:
     i__1 = *kev + 1 + *kev * h_dim;
     if (h[i__1].r > 0.0f)
     {
-        cgemv_("N", n, &kplusp, &c_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &c_zero, &workd[*n + 1], &c__1);
+        cgemv_("N", n, &kplusp, &c_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &c_zero, &workd[*n], &c__1);
     }
 
     /* -------------------------------------------------------- */
@@ -539,8 +536,8 @@ L100:
     for (i = 1; i <= i__1; ++i)
     {
         i__2 = kplusp - i + 1;
-        cgemv_("N", n, &i__2, &c_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &c_zero, &workd[1], &c__1);
-        ccopy_(n, &workd[1], &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
+        cgemv_("N", n, &i__2, &c_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &c_zero, workd, &c__1);
+        ccopy_(n, workd, &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------------------- */
@@ -556,7 +553,7 @@ L100:
     i__1 = *kev + 1 + *kev * h_dim;
     if (h[i__1].r > 0.0f)
     {
-        ccopy_(n, &workd[*n + 1], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
+        ccopy_(n, &workd[*n], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------- */
@@ -567,11 +564,11 @@ L100:
     /*    betak = e_{kev+1}'*H*e_{kev}     */
     /* ----------------------------------- */
 
-    cscal_(n, &q[kplusp + *kev * q_dim], &resid[1], &c__1);
+    cscal_(n, &q[kplusp + *kev * q_dim], resid, &c__1);
     i__1 = *kev + 1 + *kev * h_dim;
     if (h[i__1].r > 0.0f)
     {
-        caxpy_(n, &h[i__1], &v[(*kev + 1) * v_dim + 1],&c__1, &resid[1], &c__1);
+        caxpy_(n, &h[i__1], &v[(*kev + 1) * v_dim + 1],&c__1, resid, &c__1);
     }
 
 #ifndef NO_TRACE

--- a/src/ARPACK/arpack-ng/SRC/cnaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/cnaup2.c
@@ -745,7 +745,7 @@ L50:
     {
         ++timing_1.nbx;
         ccopy_(n, resid, &c__1, &workd[*n], &c__1);
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;

--- a/src/ARPACK/arpack-ng/SRC/cnaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/cnaup2.c
@@ -173,7 +173,7 @@ int cnaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
             int *info)
 {
     /* System generated locals */
-    int h_dim, h_offset, q_offset, v_offset, i__1, i__2;
+    int i__1, i__2;
     float r__1, r__2, r__3, r__4;
     complex q__1;
 
@@ -188,8 +188,7 @@ int cnaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     static float eps23;
     int ierr;
     static int iter;
-    static bool getv0;
-    static bool cnorm;
+    static bool getv0, cnorm;
     static int nconv;
     float rtemp;
     static bool initv;
@@ -200,22 +199,6 @@ int cnaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     int nptemp;
     char wprime[3];
     complex cmpnorm;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    --rwork;
-    --workl;
-    --bounds;
-    --ritz;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    h_dim = *ldh;
-    h_offset = 1 + h_dim;
-    h -= h_offset;
-    q_offset = 1 + *ldq;
-    q -= q_offset;
-    --ipntr;
 
     /* Function Body */
     if (*ido == 0)
@@ -283,7 +266,7 @@ int cnaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
 
     if (getv0)
     {
-        cgetv0_(ido, bmat, &c__1, &initv, n, &c__1, &v[v_offset], ldv, &resid[1], &rnorm, &ipntr[1], &workd[1], info);
+        cgetv0_(ido, bmat, &c__1, &initv, n, &c__1, v, ldv, resid, &rnorm, ipntr, workd, info);
 
         if (*ido != 99)
         {
@@ -336,7 +319,7 @@ int cnaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     /* Compute the first NEV steps of the Arnoldi factorization */
     /* -------------------------------------------------------- */
 
-    cnaitr_(ido, bmat, n, &c__0, nev, mode, &resid[1], &rnorm, &v[v_offset], ldv, &h[h_offset], ldh, &ipntr[1], &workd[1], info);
+    cnaitr_(ido, bmat, n, &c__0, nev, mode, resid, &rnorm, v, ldv, h, ldh, ipntr, workd, info);
 
     if (*ido != 99)
     {
@@ -394,7 +377,7 @@ L1000:
 L20:
     update = true;
 
-    cnaitr_(ido, bmat, n, nev, np, mode, &resid[1], &rnorm, &v[v_offset], ldv,&h[h_offset], ldh, &ipntr[1], &workd[1], info);
+    cnaitr_(ido, bmat, n, nev, np, mode, resid, &rnorm, v, ldv,h, ldh, ipntr, workd, info);
 
     if (*ido != 99)
     {
@@ -422,7 +405,7 @@ L20:
     /* of the current upper Hessenberg matrix.                */
     /* ------------------------------------------------------ */
 
-    cneigh_(&rnorm, &kplusp, &h[h_offset], ldh, &ritz[1], &bounds[1], &q[q_offset], ldq, &workl[1], &rwork[1], &ierr);
+    cneigh_(&rnorm, &kplusp, h, ldh, ritz, bounds, q, ldq, workl, rwork, &ierr);
 
     if (ierr != 0)
     {
@@ -448,8 +431,8 @@ L20:
 
     /* Computing 2nd power */
     i__1 = kplusp * kplusp;
-    ccopy_(&kplusp, &ritz[1], &c__1, &workl[i__1 + 1], &c__1);
-    ccopy_(&kplusp, &bounds[1], &c__1, &workl[i__1 + kplusp + 1], &c__1);
+    ccopy_(&kplusp, ritz, &c__1, &workl[i__1], &c__1);
+    ccopy_(&kplusp, bounds, &c__1, &workl[i__1 + kplusp], &c__1);
 
     /* ------------------------------------------------- */
     /* Select the wanted Ritz values and their bounds    */
@@ -459,7 +442,7 @@ L20:
     /* BOUNDS respectively.                              */
     /* ------------------------------------------------- */
 
-    cngets_(ishift, which, nev, np, &ritz[1], &bounds[1]);
+    cngets_(ishift, which, nev, np, ritz, bounds);
 
     /* ---------------------------------------------------------- */
     /* Convergence test: currently we use the following criteria. */
@@ -473,7 +456,7 @@ L20:
     nconv = 0;
 
     i__1 = *nev;
-    for (i = 1; i <= i__1; ++i)
+    for (i = 0; i < i__1; ++i)
     {
         /* Computing MAX */
         i__2 = *np + i;
@@ -492,8 +475,8 @@ L20:
         kp[1] = *np;
         kp[2] = nconv;
         ivout_(&c__3, kp, &debug_1.ndigit, "_naup2: NEV, NP, NCONV are");
-        cvout_(&kplusp, &ritz[1], &debug_1.ndigit, "_naup2: The eigenvalues of H");
-        cvout_(&kplusp, &bounds[1], &debug_1.ndigit, "_naup2: Ritz estimates of the current NCV Ritz values");
+        cvout_(&kplusp, ritz, &debug_1.ndigit, "_naup2: The eigenvalues of H");
+        cvout_(&kplusp, bounds, &debug_1.ndigit, "_naup2: Ritz estimates of the current NCV Ritz values");
     }
 #endif
 
@@ -508,7 +491,7 @@ L20:
     /* ------------------------------------------------------- */
 
     nptemp = *np;
-    for (j = 1; j <= nptemp; ++j)
+    for (j = 0; j < nptemp; ++j)
     {
         if (bounds[j].r == 0.0f && bounds[j].i == 0.0f)
         {
@@ -525,8 +508,8 @@ L20:
         {
             /* Computing 2nd power */
             i__1 = kplusp * kplusp;
-            cvout_(&kplusp, &workl[i__1 + 1], &debug_1.ndigit, "_naup2: Eigenvalues computed by _neigh:");
-            cvout_(&kplusp, &workl[i__1 + kplusp + 1],&debug_1.ndigit, "_naup2: Ritz estimates computed by _neigh:");
+            cvout_(&kplusp, &workl[i__1], &debug_1.ndigit, "_naup2: Eigenvalues computed by _neigh:");
+            cvout_(&kplusp, &workl[i__1 + kplusp],&debug_1.ndigit, "_naup2: Ritz estimates computed by _neigh:");
         }
 #endif
 
@@ -541,9 +524,8 @@ L20:
         /*  Use h( 3,1 ) as storage to communicate  */
         /*  rnorm to cneupd if needed               */
         /* ---------------------------------------- */
-        i__1 = h_dim + 3;
-        q__1.r = rnorm, q__1.i = 0.0f;
-        h[i__1].r = q__1.r, h[i__1].i = q__1.i;
+        h[2].r = rnorm;
+        h[2].i = 0.0f;
 
         /* -------------------------------------------- */
         /* Sort Ritz values so that converged Ritz      */
@@ -577,20 +559,20 @@ L20:
             strcpy(wprime, "LI");
         }
 
-        csortc_(wprime, &c_true, &kplusp, &ritz[1], &bounds[1]);
+        csortc_(wprime, &c_true, &kplusp, ritz, bounds);
 
         /* ------------------------------------------------ */
         /* Scale the Ritz estimate of each Ritz value       */
         /* by 1 / max(eps23, magnitude of the Ritz value).  */
         /* ------------------------------------------------ */
 
-        for (j = 1; j <= nev0; ++j)
+        for (j = 0; j < nev0; ++j)
         {
             /* Computing MAX */
             r__1 = eps23, r__2 = slapy2_(&ritz[j].r, &ritz[j].i);
             rtemp = dmax(r__1,r__2);
-            q__1.r = bounds[j].r / rtemp, q__1.i = bounds[j].i / rtemp;
-            bounds[j].r = q__1.r, bounds[j].i = q__1.i;
+            bounds[j].r = bounds[j].r / rtemp;
+            bounds[j].i = bounds[j].i / rtemp;
         }
 
         /* ------------------------------------------------- */
@@ -601,20 +583,20 @@ L20:
         /* ------------------------------------------------- */
 
         strcpy(wprime, "LM");
-        csortc_(wprime, &c_true, &nev0, &bounds[1], &ritz[1]);
+        csortc_(wprime, &c_true, &nev0, bounds, ritz);
 
         /* -------------------------------------------- */
         /* Scale the Ritz estimate back to its original */
         /* value.                                       */
         /* -------------------------------------------- */
 
-        for (j = 1; j <= nev0; ++j)
+        for (j = 0; j < nev0; ++j)
         {
             /* Computing MAX */
             r__1 = eps23, r__2 = slapy2_(&ritz[j].r, &ritz[j].i);
             rtemp = dmax(r__1,r__2);
-            q__1.r = rtemp * bounds[j].r, q__1.i = rtemp * bounds[j].i;
-            bounds[j].r = q__1.r, bounds[j].i = q__1.i;
+            bounds[j].r = rtemp * bounds[j].r;
+            bounds[j].i = rtemp * bounds[j].i;
         }
 
         /* --------------------------------------------- */
@@ -623,13 +605,13 @@ L20:
         /* ritz and bound.                               */
         /* --------------------------------------------- */
 
-        csortc_(which, &c_true, &nconv, &ritz[1], &bounds[1]);
+        csortc_(which, &c_true, &nconv, ritz, bounds);
 
 #ifndef NO_TRACE
         if (msglvl > 1)
         {
-            cvout_(&kplusp, &ritz[1], &debug_1.ndigit, "_naup2: Sorted eigenvalues");
-            cvout_(&kplusp, &bounds[1], &debug_1.ndigit, "_naup2: Sorted ritz estimates.");
+            cvout_(&kplusp, ritz, &debug_1.ndigit, "_naup2: Sorted eigenvalues");
+            cvout_(&kplusp, bounds, &debug_1.ndigit, "_naup2: Sorted ritz estimates.");
         }
 #endif
 
@@ -683,7 +665,7 @@ L20:
 
         if (nevbef < *nev)
         {
-            cngets_(ishift, which, nev, np, &ritz[1], &bounds[1]);
+            cngets_(ishift, which, nev, np, ritz, bounds);
         }
     }
 
@@ -696,8 +678,8 @@ L20:
             kp[0] = *nev;
             kp[1] = *np;
             ivout_(&c__2, kp, &debug_1.ndigit, "_naup2: NEV and NP are");
-            cvout_(nev, &ritz[*np + 1], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values ");
-            cvout_(nev, &bounds[*np + 1], &debug_1.ndigit, "_naup2: Ritz estimates of the \"wanted\" values ");
+            cvout_(nev, &ritz[*np], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values ");
+            cvout_(nev, &bounds[*np], &debug_1.ndigit, "_naup2: Ritz estimates of the \"wanted\" values ");
         }
     }
 #endif
@@ -724,17 +706,17 @@ L50:
         /* for non-exact shift case.        */
         /* -------------------------------- */
 
-        ccopy_(np, &workl[1], &c__1, &ritz[1], &c__1);
+        ccopy_(np, workl, &c__1, ritz, &c__1);
     }
 
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
         ivout_(&c__1, np, &debug_1.ndigit, "_naup2: The number of shifts to apply ");
-        cvout_(np, &ritz[1], &debug_1.ndigit, "_naup2: values of the shifts");
+        cvout_(np, ritz, &debug_1.ndigit, "_naup2: values of the shifts");
         if (*ishift == 1)
         {
-            cvout_(np, &bounds[1], &debug_1.ndigit, "_naup2: Ritz estimates of the shifts");
+            cvout_(np, bounds, &debug_1.ndigit, "_naup2: Ritz estimates of the shifts");
         }
     }
 #endif
@@ -746,7 +728,7 @@ L50:
     /* The first 2*N locations of WORKD are used as workspace. */
     /* ------------------------------------------------------- */
 
-    cnapps_(n, nev, np, &ritz[1], &v[v_offset], ldv, &h[h_offset], ldh, &resid[1], &q[q_offset], ldq, &workl[1], &workd[1]);
+    cnapps_(n, nev, np, ritz, v, ldv, h, ldh, resid, q, ldq, workl, workd);
 
     /* ------------------------------------------- */
     /* Compute the B-norm of the updated residual. */
@@ -762,9 +744,10 @@ L50:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        ccopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        ccopy_(n, resid, &c__1, &workd[*n], &c__1);
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
 
         /* -------------------------------- */
@@ -775,7 +758,7 @@ L50:
     }
     else if (*bmat == 'I')
     {
-        ccopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        ccopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L100:
@@ -791,15 +774,12 @@ L100:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        cdotc_(&q__1, n, &resid[1], &c__1, &workd[1], &c__1);
-        cmpnorm.r = q__1.r, cmpnorm.i = q__1.i;
-        r__1 = cmpnorm.r;
-        r__2 = cmpnorm.i;
-        rnorm = sqrt(slapy2_(&r__1, &r__2));
+        cdotc_(&cmpnorm, n, resid, &c__1, workd, &c__1);
+        rnorm = sqrt(slapy2_(&cmpnorm.r, &cmpnorm.i));
     }
     else if (*bmat == 'I')
     {
-        rnorm = scnrm2_(n, &resid[1], &c__1);
+        rnorm = scnrm2_(n, resid, &c__1);
     }
     cnorm = false;
 
@@ -807,7 +787,7 @@ L100:
     if (msglvl > 2)
     {
         svout_(&c__1, &rnorm, &debug_1.ndigit, "_naup2: B-norm of residual for compressed factorization");
-        cmout_(nev, nev, &h[h_offset], ldh, &debug_1.ndigit, "_naup2: Compressed upper Hessenberg matrix H");
+        cmout_(nev, nev, h, ldh, &debug_1.ndigit, "_naup2: Compressed upper Hessenberg matrix H");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/cnaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/cnaupd.c
@@ -537,7 +537,7 @@ int cnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 
         /* Computing 2nd power */
         i__1 = *ncv;
-        /* TODO: subtract 1 !!! */
+        /* TODO: ipntr index */
         ipntr[3] = 1 + iw + i__1 * i__1 + i__1 * 3;
         ipntr[4] = 1;
         ipntr[5] = 1 + ritz;

--- a/src/ARPACK/arpack-ng/SRC/cnaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/cnaupd.c
@@ -383,7 +383,7 @@ int cnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 {
 
     /* System generated locals */
-    int v_offset, i__1, i__2;
+    int i__1, i__2;
 
     /* Local variables */
     int j, ierr;
@@ -394,21 +394,10 @@ int cnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 
     int ldh = *ncv;
     int ldq = *ncv;
-    int ih = 1;
-    int ritz = ih + ldh * *ncv;
+    int ritz = ldh * *ncv;
     int bounds = ritz + *ncv;
     int iq = bounds + *ncv;
     int iw = iq + ldq * *ncv;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    --rwork;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    --iparam;
-    --ipntr;
-    --workl;
 
     /* Function Body */
     if (*ido == 0)
@@ -428,16 +417,16 @@ int cnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
         /* -------------- */
 
         ierr = 0;
-        ishift = iparam[1];
-        /*         levec  = iparam(2) */
-        mxiter = iparam[3];
-        /*         nb     = iparam(4) */
+        ishift = iparam[0];
+        /* levec  = iparam(2) */
+        mxiter = iparam[2];
+        /* nb     = iparam(4) */
 
         /* ------------------------------------------ */
         /* Revision 2 performs only implicit restart. */
         /* ------------------------------------------ */
 
-        mode = iparam[7];
+        mode = iparam[6];
 
         if (*n <= 0)
         {
@@ -524,7 +513,7 @@ int cnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
         /* Computing 2nd power */
         i__2 = *ncv;
         i__1 = i__2 * i__2 * 3 + *ncv * 5;
-        for (j = 1; j <= i__1; ++j)
+        for (j = 0; j < i__1; ++j)
         {
             workl[j].r = 0.0f, workl[j].i = 0.0f;
         }
@@ -548,19 +537,20 @@ int cnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 
         /* Computing 2nd power */
         i__1 = *ncv;
-        ipntr[4] = iw + i__1 * i__1 + i__1 * 3;
-        ipntr[5] = ih;
-        ipntr[6] = ritz;
-        ipntr[7] = iq;
-        ipntr[8] = bounds;
-        ipntr[14] = iw;
+        /* TODO: subtract 1 !!! */
+        ipntr[3] = 1 + iw + i__1 * i__1 + i__1 * 3;
+        ipntr[4] = 1;
+        ipntr[5] = 1 + ritz;
+        ipntr[6] = 1 + iq;
+        ipntr[7] = 1 + bounds;
+        ipntr[13] = 1 + iw;
     }
 
     /* ----------------------------------------------------- */
     /* Carry out the Implicitly restarted Arnoldi Iteration. */
     /* ----------------------------------------------------- */
 
-    cnaup2_(ido, bmat, n, which, &nev0, &np, tol, &resid[1], &mode, &iupd, &ishift, &mxiter, &v[v_offset], ldv, &workl[ih], &ldh, &workl[ritz], &workl[bounds], &workl[iq], &ldq, &workl[iw], &ipntr[1], &workd[1], &rwork[1], info);
+    cnaup2_(ido, bmat, n, which, &nev0, &np, tol, resid, &mode, &iupd, &ishift, &mxiter, v, ldv, workl, &ldh, &workl[ritz], &workl[bounds], &workl[iq], &ldq, &workl[iw], ipntr, workd, rwork, info);
 
     /* ------------------------------------------------ */
     /* ido .ne. 99 implies use of reverse communication */
@@ -569,18 +559,18 @@ int cnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 
     if (*ido == 3)
     {
-        iparam[8] = np;
+        iparam[7] = np;
     }
     if (*ido != 99)
     {
         goto L9000;
     }
 
-    iparam[3] = mxiter;
-    iparam[5] = np;
-    iparam[9] = timing_1.nopx;
-    iparam[10] = timing_1.nbx;
-    iparam[11] = timing_1.nrorth;
+    iparam[2] = mxiter;
+    iparam[4] = np;
+    iparam[8] = timing_1.nopx;
+    iparam[9] = timing_1.nbx;
+    iparam[10] = timing_1.nrorth;
 
     /* ---------------------------------- */
     /* Exit if there was an informational */

--- a/src/ARPACK/arpack-ng/SRC/cneigh.c
+++ b/src/ARPACK/arpack-ng/SRC/cneigh.c
@@ -102,7 +102,7 @@ int cneigh_(float *rnorm, int *n, complex *h, int *
             complex *workl, float *rwork, int *ierr)
 {
     /* System generated locals */
-    int h_offset, q_dim, q_offset, i__1;
+    int q_dim, i__1;
     float r__1;
 
     /* Local variables */
@@ -113,22 +113,12 @@ int cneigh_(float *rnorm, int *n, complex *h, int *
     bool select[1];
     int msglvl;
 
-
     /* ----------------------------- */
     /* Initialize timing statistics  */
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --rwork;
-    --workl;
-    --bounds;
-    --ritz;
-    h_offset = 1 + *ldh;
-    h -= h_offset;
     q_dim = *ldq;
-    q_offset = 1 + q_dim;
-    q -= q_offset;
 
     /* Function Body */
 #ifndef NO_TIMER
@@ -140,7 +130,7 @@ int cneigh_(float *rnorm, int *n, complex *h, int *
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
-        cmout_(n, n, &h[h_offset], ldh, &debug_1.ndigit, "_neigh: Entering upper Hessenberg matrix H ");
+        cmout_(n, n, h, ldh, &debug_1.ndigit, "_neigh: Entering upper Hessenberg matrix H ");
     }
 #endif
 
@@ -152,19 +142,19 @@ int cneigh_(float *rnorm, int *n, complex *h, int *
     /*    in WORKL(1:N**2), and the Schur vectors in q.         */
     /* -------------------------------------------------------- */
 
-    clacpy_("A", n, n, &h[h_offset], ldh, &workl[1], n);
-    claset_("A", n, n, &c_zero, &c_one, &q[q_offset], ldq);
-    clahqr_(&c_true, &c_true, n, &c__1, n, &workl[1], ldh, &ritz[1], &c__1, n,&q[q_offset], ldq, ierr);
+    clacpy_("A", n, n, h, ldh, workl, n);
+    claset_("A", n, n, &c_zero, &c_one, q, ldq);
+    clahqr_(&c_true, &c_true, n, &c__1, n, workl, ldh, ritz, &c__1, n,q, ldq, ierr);
     if (*ierr != 0)
     {
         goto L9000;
     }
 
-    ccopy_(n, &q[*n - 1 + q_dim], ldq, &bounds[1], &c__1);
+    ccopy_(n, &q[*n - 2], ldq, bounds, &c__1);
 #ifndef NO_TRACE
     if (msglvl > 1)
     {
-        cvout_(n, &bounds[1], &debug_1.ndigit, "_neigh: last row of the Schur matrix for H");
+        cvout_(n, bounds, &debug_1.ndigit, "_neigh: last row of the Schur matrix for H");
     }
 #endif
 
@@ -174,7 +164,7 @@ int cneigh_(float *rnorm, int *n, complex *h, int *
     /*    eigenvectors.                                         */
     /* -------------------------------------------------------- */
 
-    ctrevc_("R", "B", select, n, &workl[1], n, vl, n, &q[q_offset], ldq, n, n, &workl[*n * *n + 1], &rwork[1], ierr);
+    ctrevc_("R", "B", select, n, workl, n, vl, n, q, ldq, n, n, &workl[*n * *n], rwork, ierr);
 
     if (*ierr != 0)
     {
@@ -191,18 +181,18 @@ int cneigh_(float *rnorm, int *n, complex *h, int *
     /* ---------------------------------------------- */
 
     i__1 = *n;
-    for (j = 1; j <= i__1; ++j)
+    for (j = 0; j < i__1; ++j)
     {
-        temp = scnrm2_(n, &q[j * q_dim + 1], &c__1);
+        temp = scnrm2_(n, &q[j * q_dim], &c__1);
         r__1 = 1.0f / temp;
-        csscal_(n, &r__1, &q[j * q_dim + 1], &c__1);
+        csscal_(n, &r__1, &q[j * q_dim], &c__1);
     }
 
 #ifndef NO_TRACE
     if (msglvl > 1)
     {
-        ccopy_(n, &q[*n + q_dim], ldq, &workl[1], &c__1);
-        cvout_(n, &workl[1], &debug_1.ndigit, "_neigh: Last row of the eigenvector matrix for H");
+        ccopy_(n, &q[*n - 1], ldq, workl, &c__1);
+        cvout_(n, workl, &debug_1.ndigit, "_neigh: Last row of the eigenvector matrix for H");
     }
 #endif
 
@@ -210,14 +200,14 @@ int cneigh_(float *rnorm, int *n, complex *h, int *
     /* Compute the Ritz estimates */
     /* -------------------------- */
 
-    ccopy_(n, &q[*n + q_dim], n, &bounds[1], &c__1);
-    csscal_(n, rnorm, &bounds[1], &c__1);
+    ccopy_(n, &q[*n - 1], n, bounds, &c__1);
+    csscal_(n, rnorm, bounds, &c__1);
 
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
-        cvout_(n, &ritz[1], &debug_1.ndigit, "_neigh: The eigenvalues of H");
-        cvout_(n, &bounds[1], &debug_1.ndigit, "_neigh: Ritz estimates for the eigenvalues of H");
+        cvout_(n, ritz, &debug_1.ndigit, "_neigh: The eigenvalues of H");
+        cvout_(n, bounds, &debug_1.ndigit, "_neigh: Ritz estimates for the eigenvalues of H");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/cneupd.c
+++ b/src/ARPACK/arpack-ng/SRC/cneupd.c
@@ -258,7 +258,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
             int *info)
 {
     /* System generated locals */
-    int v_offset, z_offset, i__1, i__2;
+    int i__1, i__2;
     float r__1, r__2, r__3, r__4;
     complex q__1, q__2;
 
@@ -288,10 +288,6 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
 
 
     /* Parameter adjustments */
-    z_offset = 1 + *ldz;
-    z -= z_offset;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
     --select;
     --workl;
 
@@ -645,8 +641,8 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
         /* NCONV in workl(iuptri).                                */
         /* ------------------------------------------------------ */
 
-        cunm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &v[v_offset], ldv, &workd[*n], &ierr);
-        clacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
+        cunm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, v, ldv, &workd[*n], &ierr);
+        clacpy_("A", n, &nconv, v, ldv, z, ldz);
 
         for (j = 1; j <= nconv; ++j)
         {
@@ -748,7 +744,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
             /* Form Z*Q.                                    */
             /* -------------------------------------------- */
 
-            ctrmm_("R", "U", "N", "N", n, &nconv, &c_one, &workl[invsub], &ldq, &z[z_offset], ldz);
+            ctrmm_("R", "U", "N", "N", n, &nconv, &c_one, &workl[invsub], &ldq, z, ldz);
         }
     }
     else
@@ -864,7 +860,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
         /* purify all the Ritz vectors together. */
         /* ------------------------------------- */
 
-        cgeru_(n, &nconv, &c_one, resid, &c__1, workev, &c__1, &z[z_offset], ldz);
+        cgeru_(n, &nconv, &c_one, resid, &c__1, workev, &c__1, z, ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/cneupd.c
+++ b/src/ARPACK/arpack-ng/SRC/cneupd.c
@@ -288,24 +288,17 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
 
 
     /* Parameter adjustments */
-    --workd;
-    --resid;
     z_offset = 1 + *ldz;
     z -= z_offset;
-    --d;
-    --rwork;
-    --workev;
-    --select;
     v_offset = 1 + *ldv;
     v -= v_offset;
-    --iparam;
-    --ipntr;
+    --select;
     --workl;
 
     /* Function Body */
     msglvl = debug_1.mceupd;
-    mode = iparam[7];
-    nconv = iparam[5];
+    mode = iparam[6];
+    nconv = iparam[4];
     *info = 0;
 
     /* ------------------------------- */
@@ -421,20 +414,20 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
     /* GRAND total of NCV * ( 3 * NCV + 4 ) locations.           */
     /* --------------------------------------------------------- */
 
-    ih = ipntr[5];
-    ritz = ipntr[6];
-    iq = ipntr[7];
-    bounds = ipntr[8];
+    ih = ipntr[4];
+    ritz = ipntr[5];
+    iq = ipntr[6];
+    bounds = ipntr[7];
     ldh = *ncv;
     ldq = *ncv;
     iheig = bounds + ldh;
     ihbds = iheig + ldh;
     iuptri = ihbds + ldh;
     invsub = iuptri + ldh * *ncv;
-    ipntr[9] = iheig;
-    ipntr[11] = ihbds;
-    ipntr[12] = iuptri;
-    ipntr[13] = invsub;
+    ipntr[8] = iheig;
+    ipntr[10] = ihbds;
+    ipntr[11] = iuptri;
+    ipntr[12] = invsub;
     wr = 1;
     iwev = wr + *ncv;
 
@@ -446,7 +439,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
     /*     _naup2.                             */
     /* --------------------------------------- */
 
-    irz = ipntr[14] + *ncv * *ncv;
+    irz = ipntr[13] + *ncv * *ncv;
     ibd = irz + *ncv;
 
     /* ---------------------------------- */
@@ -518,7 +511,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
             r__1 = eps23, r__2 = slapy2_(&workl[i__2].r, &workl[i__2].i);
             rtemp = dmax(r__1,r__2);
             i__2 = bounds + *ncv - j;
-            jj = workl[i__2].r;
+            jj = (int)  workl[i__2].r;
             i__2 = ibd + jj - 1;
             if (numcnv < nconv && slapy2_(&workl[i__2].r, &workl[i__2].i) <= *tol * rtemp)
             {
@@ -589,7 +582,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
             /* Reorder the computed upper triangular matrix. */
             /* --------------------------------------------- */
 
-            ctrsen_("N", "V", &select[1], ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq, &workl[iheig], &nconv2, &conds, &sep,&workev[1], ncv, &ierr);
+            ctrsen_("N", "V", &select[1], ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq, &workl[iheig], &nconv2, &conds, &sep,workev, ncv, &ierr);
 
             if (nconv2 < nconv)
             {
@@ -629,7 +622,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
 
         if (strcmp(type, "REGULR") == 0)
         {
-            ccopy_(&nconv, &workl[iheig], &c__1, &d[1], &c__1);
+            ccopy_(&nconv, &workl[iheig], &c__1, d, &c__1);
         }
 
         /* -------------------------------------------------------- */
@@ -638,7 +631,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
         /* columns of workl(invsub,ldq).                            */
         /* -------------------------------------------------------- */
 
-        cgeqr2_(ncv, &nconv, &workl[invsub], &ldq, &workev[1], &workev[*ncv + 1], &ierr);
+        cgeqr2_(ncv, &nconv, &workl[invsub], &ldq, workev, &workev[*ncv], &ierr);
 
         /* ------------------------------------------------------ */
         /* * Postmultiply V by Q using cunm2r.                    */
@@ -652,7 +645,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
         /* NCONV in workl(iuptri).                                */
         /* ------------------------------------------------------ */
 
-        cunm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, &workev[1], &v[v_offset], ldv, &workd[*n + 1], &ierr);
+        cunm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &v[v_offset], ldv, &workd[*n], &ierr);
         clacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
 
         for (j = 1; j <= nconv; ++j)
@@ -669,9 +662,9 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
             i__2 = invsub + (j - 1) * ldq + j - 1;
             if (workl[i__2].r < 0.0f)
             {
-                q__1.r = -1.f, q__1.i = -0.0f;
+                q__1.r = -1.0f, q__1.i = -0.0f;
                 cscal_(&nconv, &q__1, &workl[iuptri + j - 1], &ldq);
-                q__1.r = -1.f, q__1.i = -0.0f;
+                q__1.r = -1.0f, q__1.i = -0.0f;
                 cscal_(&nconv, &q__1, &workl[iuptri + (j - 1) * ldq], &c__1);
             }
         }
@@ -696,7 +689,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
                 }
             }
 
-            ctrevc_("R", "S", &select[1], ncv, &workl[iuptri], &ldq, vl, &c__1, &workl[invsub], &ldq, ncv, &outncv, &workev[1],&rwork[1], &ierr);
+            ctrevc_("R", "S", &select[1], ncv, &workl[iuptri], &ldq, vl, &c__1, &workl[invsub], &ldq, ncv, &outncv, workev,rwork, &ierr);
 
             if (ierr != 0)
             {
@@ -712,11 +705,11 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
             /* magnitude 1.                                   */
             /* ---------------------------------------------- */
 
-            for (j = 1; j <= nconv; ++j)
+            for (j = 0; j < nconv; ++j)
             {
-                rtemp = scnrm2_(ncv, &workl[invsub + (j - 1) * ldq], &c__1);
+                rtemp = scnrm2_(ncv, &workl[invsub + j * ldq], &c__1);
                 rtemp = 1.0f / rtemp;
-                csscal_(ncv, &rtemp, &workl[invsub + (j - 1) * ldq], &c__1);
+                csscal_(ncv, &rtemp, &workl[invsub + j * ldq], &c__1);
 
                 /* ---------------------------------------- */
                 /* Ritz estimates can be obtained by taking */
@@ -727,7 +720,8 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
                 /* inner product can be set to j.           */
                 /* ---------------------------------------- */
 
-                cdotc_(&q__1, &j, &workl[ihbds], &c__1, &workl[invsub + (j - 1) * ldq], &c__1);
+                i__2 = j + 1;
+                cdotc_(&q__1, &i__2, &workl[ihbds], &c__1, &workl[invsub + j * ldq], &c__1);
                 workev[j].r = q__1.r, workev[j].i = q__1.i;
             }
 
@@ -747,7 +741,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
             /* Copy Ritz estimates into workl(ihbds) */
             /* ------------------------------------- */
 
-            ccopy_(&nconv, &workev[1], &c__1, &workl[ihbds], &c__1);
+            ccopy_(&nconv, workev, &c__1, &workl[ihbds], &c__1);
 
             /* -------------------------------------------- */
             /* The eigenvector matrix Q of T is triangular. */
@@ -764,7 +758,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
         /* Place the Ritz values computed CNAUPD into D.    */
         /* ------------------------------------------------ */
 
-        ccopy_(&nconv, &workl[ritz], &c__1, &d[1], &c__1);
+        ccopy_(&nconv, &workl[ritz], &c__1, d, &c__1);
         ccopy_(&nconv, &workl[ritz], &c__1, &workl[iheig], &c__1);
         ccopy_(&nconv, &workl[bounds], &c__1, &workl[ihbds], &c__1);
     }
@@ -796,12 +790,12 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
         }
 
         i__1 = *ncv;
-        for (k = 1; k <= i__1; ++k)
+        for (k = 0; k < i__1; ++k)
         {
-            i__2 = iheig + k - 1;
+            i__2 = iheig + k;
             temp.r = workl[i__2].r, temp.i = workl[i__2].i;
-            i__2 = ihbds + k - 1;
-            c_div(&q__2, &workl[ihbds + k - 1], &temp);
+            i__2 = ihbds + k;
+            c_div(&q__2, &workl[ihbds + k], &temp);
             c_div(&q__1, &q__2, &temp);
             workl[i__2].r = q__1.r, workl[i__2].i = q__1.i;
         }
@@ -817,23 +811,23 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
 
     if (strcmp(type, "SHIFTI") == 0)
     {
-        for (k = 1; k <= nconv; ++k)
+        for (k = 0; k < nconv; ++k)
         {
-            c_div(&q__2, &c_one, &workl[iheig + k - 1]);
-            q__1.r = q__2.r + sigma->r, q__1.i = q__2.i + sigma->i;
-            d[k].r = q__1.r, d[k].i = q__1.i;
+            c_div(&q__2, &c_one, &workl[iheig + k]);
+            d[k].r = q__2.r + sigma->r;
+            d[k].i = q__2.i + sigma->i;
         }
     }
 
 #ifndef NO_TRACE
     if (msglvl > 1 && strcmp(type, "REGULR") != 0)
     {
-        cvout_(&nconv, &d[1], &debug_1.ndigit, "_neupd: Untransformed Ritz values.");
+        cvout_(&nconv, d, &debug_1.ndigit, "_neupd: Untransformed Ritz values.");
         cvout_(&nconv, &workl[ihbds], &debug_1.ndigit, "_neupd: Ritz estimates of the untransformed Ritz values.");
     }
     else if (msglvl > 1)
     {
-        cvout_(&nconv, &d[1], &debug_1.ndigit, "_neupd: Converged Ritz values.");
+        cvout_(&nconv, d, &debug_1.ndigit, "_neupd: Converged Ritz values.");
         cvout_(&nconv, &workl[ihbds], &debug_1.ndigit, "_neupd: Associated Ritz estimates.");
     }
 #endif
@@ -855,12 +849,12 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
         /* where H s = s theta.                           */
         /* ---------------------------------------------- */
 
-        for (j = 1; j <= nconv; ++j)
+        for (j = 0; j < nconv; ++j)
         {
-            i__2 = iheig + j - 1;
+            i__2 = iheig + j;
             if (workl[i__2].r != 0.0f || workl[i__2].i != 0.0f)
             {
-                c_div(&q__1, &workl[invsub + (j - 1) * ldq + *ncv - 1], &workl[i__2]);
+                c_div(&q__1, &workl[invsub + j * ldq + *ncv - 1], &workl[i__2]);
                 workev[j].r = q__1.r, workev[j].i = q__1.i;
             }
         }
@@ -870,7 +864,7 @@ int cneupd_(bool *rvec, char *howmny, bool *select, complex *d, complex *z, int 
         /* purify all the Ritz vectors together. */
         /* ------------------------------------- */
 
-        cgeru_(n, &nconv, &c_one, &resid[1], &c__1, &workev[1], &c__1, &z[z_offset], ldz);
+        cgeru_(n, &nconv, &c_one, resid, &c__1, workev, &c__1, &z[z_offset], ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/cngets.c
+++ b/src/ARPACK/arpack-ng/SRC/cngets.c
@@ -99,10 +99,6 @@ int cngets_(int *ishift, char *which, int *kev, int *np, complex *ritz, complex 
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --bounds;
-    --ritz;
-
     /* Function Body */
 #ifndef NO_TIMER
     arscnd_(&t0);
@@ -111,7 +107,7 @@ int cngets_(int *ishift, char *which, int *kev, int *np, complex *ritz, complex 
     msglvl = debug_1.mcgets;
 
     i__1 = *kev + *np;
-    csortc_(which, &c_true, &i__1, &ritz[1], &bounds[1]);
+    csortc_(which, &c_true, &i__1, ritz, bounds);
 
     if (*ishift == 1)
     {
@@ -124,7 +120,7 @@ int cngets_(int *ishift, char *which, int *kev, int *np, complex *ritz, complex 
         /* Be careful and use 'SM' since we want to sort BOUNDS! */
         /* ----------------------------------------------------- */
 
-        csortc_("SM", &c_true, np, &bounds[1], &ritz[1]);
+        csortc_("SM", &c_true, np, bounds, ritz);
     }
 
 #ifndef NO_TIMER
@@ -137,8 +133,8 @@ int cngets_(int *ishift, char *which, int *kev, int *np, complex *ritz, complex 
     {
         ivout_(&c__1, kev, &debug_1.ndigit, "_ngets: KEV is");
         ivout_(&c__1, np, &debug_1.ndigit, "_ngets: NP is");
-        cvout_(&i__1, &ritz[1], &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix ");
-        cvout_(&i__1, &bounds[1], &debug_1.ndigit, "_ngets: Ritz estimates of the current KEV+NP Ritz values");
+        cvout_(&i__1, ritz, &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix ");
+        cvout_(&i__1, bounds, &debug_1.ndigit, "_ngets: Ritz estimates of the current KEV+NP Ritz values");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/dgetv0.c
+++ b/src/ARPACK/arpack-ng/SRC/dgetv0.c
@@ -203,7 +203,7 @@ int dgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (*itry == 1)
         {
             ++timing_1.nopx;
-            /* TODO: subtract 1 */
+            /* TODO: ipntr index */
             ipntr[0] = 1;
             ipntr[1] = *n + 1;
             dcopy_(n, resid, &c__1, workd, &c__1);
@@ -259,7 +259,7 @@ int dgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;
@@ -328,7 +328,7 @@ L30:
     {
         ++timing_1.nbx;
         dcopy_(n, resid, &c__1, &workd[*n], &c__1);
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;

--- a/src/ARPACK/arpack-ng/SRC/dgetv0.c
+++ b/src/ARPACK/arpack-ng/SRC/dgetv0.c
@@ -125,7 +125,7 @@ int dgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     static bool inits = true;
 
     /* System generated locals */
-    int v_offset, i__1;
+    int i__1;
 
     /* Builtin functions */
     double sqrt(double);
@@ -140,13 +140,6 @@ int dgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     static bool first;
     static double rnorm0;
     static int msglvl;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    --ipntr;
 
     /* Function Body */
 
@@ -195,7 +188,7 @@ int dgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (! (*initv))
         {
             idist = 2;
-            dlarnv_(&idist, iseed, n, &resid[1]);
+            dlarnv_(&idist, iseed, n, resid);
         }
 
         /* -------------------------------------------------------- */
@@ -210,15 +203,16 @@ int dgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (*itry == 1)
         {
             ++timing_1.nopx;
-            ipntr[1] = 1;
-            ipntr[2] = *n + 1;
-            dcopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+            /* TODO: subtract 1 */
+            ipntr[0] = 1;
+            ipntr[1] = *n + 1;
+            dcopy_(n, resid, &c__1, workd, &c__1);
             *ido = -1;
             goto L9000;
         }
         else if (*itry > 1 && *bmat == 'G')
         {
-            dcopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
+            dcopy_(n, resid, &c__1, &workd[*n], &c__1);
         }
     }
 
@@ -260,19 +254,20 @@ int dgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     first = true;
     if (*itry == 1)
     {
-        dcopy_(n, &workd[*n + 1], &c__1, &resid[1], &c__1);
+        dcopy_(n, &workd[*n], &c__1, resid, &c__1);
     }
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
         goto L9000;
     }
     else if (*bmat == 'I')
     {
-        dcopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        dcopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L20:
@@ -284,12 +279,12 @@ L20:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        rnorm0 = ddot_(n, &resid[1], &c__1, &workd[1], &c__1);
+        rnorm0 = ddot_(n, resid, &c__1, workd, &c__1);
         rnorm0 = sqrt((abs(rnorm0)));
     }
     else if (*bmat == 'I')
     {
-        rnorm0 = dnrm2_(n, &resid[1], &c__1);
+        rnorm0 = dnrm2_(n, resid, &c__1);
     }
     *rnorm = rnorm0;
 
@@ -318,8 +313,8 @@ L20:
 L30:
 
     i__1 = *j - 1;
-    dgemv_("T", n, &i__1, &d_one, &v[v_offset], ldv, &workd[1], &c__1, &d_zero,&workd[*n + 1], &c__1);
-    dgemv_("N", n, &i__1, &d_m1, &v[v_offset], ldv, &workd[*n + 1], &c__1, &d_one, &resid[1], &c__1);
+    dgemv_("T", n, &i__1, &d_one, v, ldv, workd, &c__1, &d_zero,&workd[*n], &c__1);
+    dgemv_("N", n, &i__1, &d_m1, v, ldv, &workd[*n], &c__1, &d_one, resid, &c__1);
 
     /* -------------------------------------------------------- */
     /* Compute the B-norm of the orthogonalized starting vector */
@@ -332,15 +327,16 @@ L30:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        dcopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        dcopy_(n, resid, &c__1, &workd[*n], &c__1);
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
         goto L9000;
     }
     else if (*bmat == 'I')
     {
-        dcopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        dcopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L40:
@@ -351,12 +347,12 @@ L40:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        *rnorm = ddot_(n, &resid[1], &c__1, &workd[1], &c__1);
+        *rnorm = ddot_(n, resid, &c__1, workd, &c__1);
         *rnorm = sqrt((abs(*rnorm)));
     }
     else if (*bmat == 'I')
     {
-        *rnorm = dnrm2_(n, &resid[1], &c__1);
+        *rnorm = dnrm2_(n, resid, &c__1);
     }
 
     /* ------------------------------------ */
@@ -393,7 +389,7 @@ L40:
         /* ---------------------------------- */
 
         i__1 = *n;
-        for (jj = 1; jj <= i__1; ++jj)
+        for (jj = 0; jj < i__1; ++jj)
         {
             resid[jj] = 0.0;
         }
@@ -411,7 +407,7 @@ L50:
 
     if (msglvl > 3)
     {
-        dvout_(n, &resid[1], &debug_1.ndigit, "_getv0: initial / restarted starting vector");
+        dvout_(n, resid, &debug_1.ndigit, "_getv0: initial / restarted starting vector");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/dnaitr.c
+++ b/src/ARPACK/arpack-ng/SRC/dnaitr.c
@@ -248,14 +248,12 @@ int dnaitr_(int *ido, char *bmat, int *n, int *k,int *np, int *nb,
 
     /* Parameter adjustments */
     --workd;
-    --resid;
     v_dim = *ldv;
     v_offset = 1 + v_dim;
     v -= v_offset;
     h_dim = *ldh;
     h_offset = 1 + h_dim;
     h -= h_offset;
-    --ipntr;
 
     /* Function Body */
 
@@ -401,7 +399,7 @@ L30:
     /* RSTART = .true. flow returns here.   */
     /* ------------------------------------ */
 
-    dgetv0_(ido, bmat, &itry, &c_false, n, &j, &v[v_offset], ldv, &resid[1], rnorm, &ipntr[1], &workd[1], &ierr);
+    dgetv0_(ido, bmat, &itry, &c_false, n, &j, &v[v_offset], ldv, resid, rnorm, ipntr, &workd[1], &ierr);
     if (*ido != 99)
     {
         goto L9000;
@@ -439,7 +437,7 @@ L40:
     /* machine bound.                                          */
     /* ------------------------------------------------------- */
 
-    dcopy_(n, &resid[1], &c__1, &v[j * v_dim + 1], &c__1);
+    dcopy_(n, resid, &c__1, &v[j * v_dim + 1], &c__1);
     if (*rnorm >= unfl)
     {
         temp1 = 1.0 / *rnorm;
@@ -469,9 +467,9 @@ L40:
 #endif
 
     dcopy_(n, &v[j * v_dim + 1], &c__1, &workd[ivj], &c__1);
-    ipntr[1] = ivj;
-    ipntr[2] = irj;
-    ipntr[3] = ipj;
+    ipntr[0] = ivj;
+    ipntr[1] = irj;
+    ipntr[2] = ipj;
     *ido = 1;
 
     /* --------------------------------- */
@@ -498,7 +496,7 @@ L50:
     /* Put another copy of OP*v_{j} into RESID. */
     /* ---------------------------------------- */
 
-    dcopy_(n, &workd[irj], &c__1, &resid[1], &c__1);
+    dcopy_(n, &workd[irj], &c__1, resid, &c__1);
 
     /* ------------------------------------- */
     /* STEP 4:  Finish extending the Arnoldi */
@@ -513,8 +511,8 @@ L50:
     {
         ++timing_1.nbx;
         step4 = true;
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* ----------------------------------- */
@@ -525,7 +523,7 @@ L50:
     }
     else if (*bmat == 'I')
     {
-        dcopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        dcopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L60:
 
@@ -548,12 +546,12 @@ L60:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        wnorm = ddot_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        wnorm = ddot_(n, resid, &c__1, &workd[ipj], &c__1);
         wnorm = sqrt((abs(wnorm)));
     }
     else if (*bmat == 'I')
     {
-        wnorm = dnrm2_(n, &resid[1], &c__1);
+        wnorm = dnrm2_(n, resid, &c__1);
     }
 
     /* --------------------------------------- */
@@ -576,7 +574,7 @@ L60:
     /* RESID contains OP*v_{j}. See STEP 3. */
     /* ------------------------------------ */
 
-    dgemv_("N", n, &j, &d_m1, &v[v_offset], ldv, &h[j * h_dim + 1], &c__1,&d_one, &resid[1], &c__1);
+    dgemv_("N", n, &j, &d_m1, &v[v_offset], ldv, &h[j * h_dim + 1], &c__1,&d_one, resid, &c__1);
 
     if (j > 1)
     {
@@ -593,9 +591,9 @@ L60:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        dcopy_(n, &resid[1], &c__1, &workd[irj], &c__1);
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        dcopy_(n, resid, &c__1, &workd[irj], &c__1);
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* -------------------------------- */
@@ -606,7 +604,7 @@ L60:
     }
     else if (*bmat == 'I')
     {
-        dcopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        dcopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L70:
 
@@ -627,12 +625,12 @@ L70:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        *rnorm = ddot_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        *rnorm = ddot_(n, resid, &c__1, &workd[ipj], &c__1);
         *rnorm = sqrt((abs(*rnorm)));
     }
     else if (*bmat == 'I')
     {
-        *rnorm = dnrm2_(n, &resid[1], &c__1);
+        *rnorm = dnrm2_(n, resid, &c__1);
     }
 
     /* --------------------------------------------------------- */
@@ -693,7 +691,7 @@ L80:
     /* + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.         */
     /* ------------------------------------------- */
 
-    dgemv_("N", n, &j, &d_m1, &v[v_offset], ldv, &workd[irj], &c__1, &d_one, &resid[1], &c__1);
+    dgemv_("N", n, &j, &d_m1, &v[v_offset], ldv, &workd[irj], &c__1, &d_one, resid, &c__1);
     daxpy_(&j, &d_one, &workd[irj], &c__1, &h[j * h_dim + 1], &c__1);
 
     orth2 = true;
@@ -704,9 +702,9 @@ L80:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        dcopy_(n, &resid[1], &c__1, &workd[irj], &c__1);
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        dcopy_(n, resid, &c__1, &workd[irj], &c__1);
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* --------------------------------- */
@@ -718,7 +716,7 @@ L80:
     }
     else if (*bmat == 'I')
     {
-        dcopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        dcopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L90:
 
@@ -736,12 +734,12 @@ L90:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        rnorm1 = ddot_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        rnorm1 = ddot_(n, resid, &c__1, &workd[ipj], &c__1);
         rnorm1 = sqrt((abs(rnorm1)));
     }
     else if (*bmat == 'I')
     {
-        rnorm1 = dnrm2_(n, &resid[1], &c__1);
+        rnorm1 = dnrm2_(n, resid, &c__1);
     }
 
 #ifndef NO_TRACE
@@ -796,7 +794,7 @@ L90:
         /* ----------------------------------------------- */
 
         i__1 = *n;
-        for (jj = 1; jj <= i__1; ++jj)
+        for (jj = 0; jj < i__1; ++jj)
         {
             resid[jj] = 0.0;
         }
@@ -840,18 +838,18 @@ L100:
             /* Use a standard test as in the QR algorithm */
             /* REFERENCE: LAPACK subroutine dlahqr        */
             /* ------------------------------------------ */
-
-            tst1 = (d__1 = h[i + i * h_dim], abs(d__1)) + (d__2 = h[
-                        i + 1 + (i + 1) * h_dim], abs(d__2));
+            d__1 = h[i + i * h_dim];
+            d__2 = h[i + 1 + (i + 1) * h_dim];
+            tst1 = abs(d__1) + abs(d__2);
             if (tst1 == 0.0)
             {
                 i__2 = *k + *np;
                 tst1 = dlanhs_("1", &i__2, &h[h_offset], ldh, &workd[*n + 1]);
             }
             /* Computing MAX */
+            d__1 = h[i + 1 + i * h_dim];
             d__2 = ulp * tst1;
-            if ((d__1 = h[i + 1 + i * h_dim], abs(d__1)) <= max(d__2,
-                    smlnum))
+            if (abs(d__1) <= max(d__2,smlnum))
             {
                 h[i + 1 + i * h_dim] = 0.0;
             }

--- a/src/ARPACK/arpack-ng/SRC/dnapps.c
+++ b/src/ARPACK/arpack-ng/SRC/dnapps.c
@@ -173,11 +173,6 @@ int dnapps_(int *n, int *kev, int *np,
     static double smlnum;
 
     /* Parameter adjustments */
-    --workd;
-    --resid;
-    --workl;
-    --shifti;
-    --shiftr;
     v_dim = *ldv;
     v_offset = 1 + v_dim;
     v -= v_offset;
@@ -245,8 +240,9 @@ int dnapps_(int *n, int *kev, int *np,
     i__1 = *np;
     for (jj = 1; jj <= i__1; ++jj)
     {
-        sigmar = shiftr[jj];
-        sigmai = shifti[jj];
+        /* TODO: fix jj - 1 */
+        sigmar = shiftr[jj - 1];
+        sigmai = shifti[jj - 1];
 
 #ifndef NO_TRACE
         if (msglvl > 2)
@@ -322,7 +318,7 @@ L20:
             if (tst1 == 0.0)
             {
                 i__3 = kplusp - jj + 1;
-                tst1 = dlanhs_("1", &i__3, &h[h_offset], ldh, &workl[1]);
+                tst1 = dlanhs_("1", &i__3, &h[h_offset], ldh, workl);
             }
             /* Computing MAX */
             d__1 = h[i + 1 + i * h_dim];
@@ -516,7 +512,7 @@ L40:
                 /* ------------------------------------ */
 
                 i__3 = kplusp - i + 1;
-                dlarf_("L", &nr, &i__3, u, &c__1, &tau, &h[i + i * h_dim], ldh, &workl[1]);
+                dlarf_("L", &nr, &i__3, u, &c__1, &tau, &h[i + i * h_dim], ldh, workl);
 
                 /* ------------------------------------- */
                 /* Apply the reflector to the right of H */
@@ -525,13 +521,13 @@ L40:
                 /* Computing MIN */
                 i__3 = i + 3;
                 ir = min(i__3,iend);
-                dlarf_("R", &ir, &nr, u, &c__1, &tau, &h[i * h_dim + 1], ldh, &workl[1]);
+                dlarf_("R", &ir, &nr, u, &c__1, &tau, &h[i * h_dim + 1], ldh, workl);
 
                 /* --------------------------------------------------- */
                 /* Accumulate the reflector in the matrix Q;  Q <- Q*G */
                 /* --------------------------------------------------- */
 
-                dlarf_("R", &kplusp, &nr, u, &c__1, &tau, &q[i * q_dim + 1], ldq, &workl[1]);
+                dlarf_("R", &kplusp, &nr, u, &c__1, &tau, &q[i * q_dim + 1], ldq, workl);
 
                 /* -------------------------- */
                 /* Prepare for next reflector */
@@ -612,7 +608,7 @@ L110:
         tst1 = abs(d__1) + abs(d__2);
         if (tst1 == 0.0)
         {
-            tst1 = dlanhs_("1", kev, &h[h_offset], ldh, &workl[1]);
+            tst1 = dlanhs_("1", kev, &h[h_offset], ldh, workl);
         }
         /* Computing MAX */
         d__1 = ulp * tst1;
@@ -632,7 +628,7 @@ L110:
 
     if (h[*kev + 1 + *kev * h_dim] > 0.0)
     {
-        dgemv_("N", n, &kplusp, &d_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &d_zero, &workd[*n + 1], &c__1);
+        dgemv_("N", n, &kplusp, &d_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &d_zero, &workd[*n], &c__1);
     }
 
     /* -------------------------------------------------------- */
@@ -644,8 +640,8 @@ L110:
     for (i = 1; i <= i__1; ++i)
     {
         i__2 = kplusp - i + 1;
-        dgemv_("N", n, &i__2, &d_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &d_zero, &workd[1], &c__1);
-        dcopy_(n, &workd[1], &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
+        dgemv_("N", n, &i__2, &d_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &d_zero, workd, &c__1);
+        dcopy_(n, workd, &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------------------- */
@@ -664,7 +660,7 @@ L110:
 
     if (h[*kev + 1 + *kev * h_dim] > 0.0)
     {
-        dcopy_(n, &workd[*n + 1], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
+        dcopy_(n, &workd[*n], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------- */
@@ -675,10 +671,10 @@ L110:
     /*    betak = e_{kev+1}'*H*e_{kev}     */
     /* ----------------------------------- */
 
-    dscal_(n, &q[kplusp + *kev * q_dim], &resid[1], &c__1);
+    dscal_(n, &q[kplusp + *kev * q_dim], resid, &c__1);
     if (h[*kev + 1 + *kev * h_dim] > 0.0)
     {
-        daxpy_(n, &h[*kev + 1 + *kev * h_dim], &v[(*kev + 1) * v_dim + 1],&c__1, &resid[1], &c__1);
+        daxpy_(n, &h[*kev + 1 + *kev * h_dim], &v[(*kev + 1) * v_dim + 1],&c__1, resid, &c__1);
     }
 
 #ifndef NO_TRACE

--- a/src/ARPACK/arpack-ng/SRC/dnaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/dnaup2.c
@@ -180,7 +180,7 @@ int dnaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
             int *info)
 {
     /* System generated locals */
-    int h_dim, h_offset, q_offset, v_offset, i__1, i__2;
+    int i__1, i__2;
     double d__1, d__2;
 
     /* Builtin functions */
@@ -206,22 +206,6 @@ int dnaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     static int kplusp, msglvl;
     int nptemp;
     static int numcnv;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    --workl;
-    --bounds;
-    --ritzi;
-    --ritzr;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    h_dim = *ldh;
-    h_offset = 1 + h_dim;
-    h -= h_offset;
-    q_offset = 1 + *ldq;
-    q -= q_offset;
-    --ipntr;
 
     /* Function Body */
     if (*ido == 0)
@@ -289,7 +273,7 @@ int dnaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
 
     if (getv0)
     {
-        dgetv0_(ido, bmat, &c__1, &initv, n, &c__1, &v[v_offset], ldv, &resid[1], &rnorm, &ipntr[1], &workd[1], info);
+        dgetv0_(ido, bmat, &c__1, &initv, n, &c__1, v, ldv, resid, &rnorm, ipntr, workd, info);
 
         if (*ido != 99)
         {
@@ -342,7 +326,7 @@ int dnaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     /* Compute the first NEV steps of the Arnoldi factorization */
     /* -------------------------------------------------------- */
 
-    dnaitr_(ido, bmat, n, &c__0, nev, mode, &resid[1], &rnorm, &v[v_offset], ldv, &h[h_offset], ldh, &ipntr[1], &workd[1], info);
+    dnaitr_(ido, bmat, n, &c__0, nev, mode, resid, &rnorm, v, ldv, h, ldh, ipntr, workd, info);
 
     /* ------------------------------------------------- */
     /* ido .ne. 99 implies use of reverse communication  */
@@ -405,7 +389,7 @@ L1000:
 L20:
     update = true;
 
-    dnaitr_(ido, bmat, n, nev, np, mode, &resid[1], &rnorm, &v[v_offset], ldv,&h[h_offset], ldh, &ipntr[1], &workd[1], info);
+    dnaitr_(ido, bmat, n, nev, np, mode, resid, &rnorm, v, ldv,h, ldh, ipntr, workd, info);
 
     /* ------------------------------------------------- */
     /* ido .ne. 99 implies use of reverse communication  */
@@ -438,7 +422,7 @@ L20:
     /* of the current upper Hessenberg matrix.                */
     /* ------------------------------------------------------ */
 
-    dneigh_(&rnorm, &kplusp, &h[h_offset], ldh, &ritzr[1], &ritzi[1], &bounds[1], &q[q_offset], ldq, &workl[1], &ierr);
+    dneigh_(&rnorm, &kplusp, h, ldh, ritzr, ritzi, bounds, q, ldq, workl, &ierr);
 
     if (ierr != 0)
     {
@@ -453,9 +437,9 @@ L20:
 
     /* Computing 2nd power */
     i__1 = kplusp * kplusp;
-    dcopy_(&kplusp, &ritzr[1], &c__1, &workl[i__1 + 1], &c__1);
-    dcopy_(&kplusp, &ritzi[1], &c__1, &workl[i__1 + kplusp + 1], &c__1);
-    dcopy_(&kplusp, &bounds[1], &c__1, &workl[i__1 + (kplusp << 1) + 1], &c__1);
+    dcopy_(&kplusp, ritzr, &c__1, &workl[i__1], &c__1);
+    dcopy_(&kplusp, ritzi, &c__1, &workl[i__1 + kplusp], &c__1);
+    dcopy_(&kplusp, bounds, &c__1, &workl[i__1 + (kplusp << 1)], &c__1);
 
     /* ------------------------------------------------- */
     /* Select the wanted Ritz values and their bounds    */
@@ -473,7 +457,7 @@ L20:
     *nev = nev0;
     *np = np0;
     numcnv = *nev;
-    dngets_(ishift, which, nev, np, &ritzr[1], &ritzi[1], &bounds[1], &workl[1], &workl[*np + 1]);
+    dngets_(ishift, which, nev, np, ritzr, ritzi, bounds, workl, &workl[*np]);
     if (*nev == nev0 + 1)
     {
         numcnv = nev0 + 1;
@@ -483,8 +467,8 @@ L20:
     /* Convergence test. */
     /* ----------------- */
 
-    dcopy_(nev, &bounds[*np + 1], &c__1, &workl[(*np << 1) + 1], &c__1);
-    dnconv_(nev, &ritzr[*np + 1], &ritzi[*np + 1], &workl[(*np << 1) + 1], tol, &nconv);
+    dcopy_(nev, &bounds[*np], &c__1, &workl[*np << 1], &c__1);
+    dnconv_(nev, &ritzr[*np], &ritzi[*np], &workl[*np << 1], tol, &nconv);
 
 #ifndef NO_TRACE
     if (msglvl > 2)
@@ -494,9 +478,9 @@ L20:
         kp[2] = numcnv;
         kp[3] = nconv;
         ivout_(&c__4, kp, &debug_1.ndigit, "_naup2: NEV, NP, NUMCNV, NCONV are");
-        dvout_(&kplusp, &ritzr[1], &debug_1.ndigit, "_naup2: Real part of the eigenvalues of H");
-        dvout_(&kplusp, &ritzi[1], &debug_1.ndigit, "_naup2: Imaginary part of the eigenvalues of H");
-        dvout_(&kplusp, &bounds[1], &debug_1.ndigit, "_naup2: Ritz estimates of the current NCV Ritz values");
+        dvout_(&kplusp, ritzr, &debug_1.ndigit, "_naup2: Real part of the eigenvalues of H");
+        dvout_(&kplusp, ritzi, &debug_1.ndigit, "_naup2: Imaginary part of the eigenvalues of H");
+        dvout_(&kplusp, bounds, &debug_1.ndigit, "_naup2: Ritz estimates of the current NCV Ritz values");
     }
 #endif
 
@@ -511,7 +495,7 @@ L20:
     /* ------------------------------------------------------- */
 
     nptemp = *np;
-    for (j = 1; j <= nptemp; ++j)
+    for (j = 0; j < nptemp; ++j)
     {
         if (bounds[j] == 0.0)
         {
@@ -528,9 +512,9 @@ L20:
         {
             /* Computing 2nd power */
             i__1 = kplusp * kplusp;
-            dvout_(&kplusp, &workl[i__1 + 1], &debug_1.ndigit, "_naup2: Real part of the eig computed by _neigh:");
-            dvout_(&kplusp, &workl[i__1 + kplusp + 1],&debug_1.ndigit, "_naup2: Imag part of the eig computed by _neigh:");
-            dvout_(&kplusp, &workl[i__1 + (kplusp << 1) + 1], &debug_1.ndigit, "_naup2: Ritz eistmates computed by _neigh:");
+            dvout_(&kplusp, &workl[i__1], &debug_1.ndigit, "_naup2: Real part of the eig computed by _neigh:");
+            dvout_(&kplusp, &workl[i__1 + kplusp],&debug_1.ndigit, "_naup2: Imag part of the eig computed by _neigh:");
+            dvout_(&kplusp, &workl[i__1 + (kplusp << 1)], &debug_1.ndigit, "_naup2: Ritz eistmates computed by _neigh:");
         }
 #endif
 
@@ -545,7 +529,7 @@ L20:
         /*  Use h( 3,1 ) as storage to communicate  */
         /*  rnorm to _neupd if needed               */
         /* ---------------------------------------- */
-        h[h_dim + 3] = rnorm;
+        h[2] = rnorm;
 
         /* -------------------------------------------- */
         /* To be consistent with dngets , we first do a */
@@ -581,7 +565,7 @@ L20:
             strcpy(wprime, "LM");
         }
 
-        dsortc_(wprime, &c_true, &kplusp, &ritzr[1], &ritzi[1], &bounds[1]);
+        dsortc_(wprime, &c_true, &kplusp, ritzr, ritzi, bounds);
 
         /* -------------------------------------------- */
         /* Now sort Ritz values so that converged Ritz  */
@@ -615,14 +599,14 @@ L20:
             strcpy(wprime, "LI");
         }
 
-        dsortc_(wprime, &c_true, &kplusp, &ritzr[1], &ritzi[1], &bounds[1]);
+        dsortc_(wprime, &c_true, &kplusp, ritzr, ritzi, bounds);
 
         /* ------------------------------------------------ */
         /* Scale the Ritz estimate of each Ritz value       */
         /* by 1 / max(eps23,magnitude of the Ritz value).   */
         /* ------------------------------------------------ */
 
-        for (j = 1; j <= numcnv; ++j)
+        for (j = 0; j < numcnv; ++j)
         {
             /* Computing MAX */
             d__1 = eps23, d__2 = dlapy2_(&ritzr[j], &ritzi[j]);
@@ -638,14 +622,14 @@ L20:
         /* -------------------------------------------------- */
 
         strcpy(wprime, "LR");
-        dsortc_(wprime, &c_true, &numcnv, &bounds[1], &ritzr[1], &ritzi[1]);
+        dsortc_(wprime, &c_true, &numcnv, bounds, ritzr, ritzi);
 
         /* -------------------------------------------- */
         /* Scale the Ritz estimate back to its original */
         /* value.                                       */
         /* -------------------------------------------- */
 
-        for (j = 1; j <= numcnv; ++j)
+        for (j = 0; j < numcnv; ++j)
         {
             /* Computing MAX */
             d__1 = eps23, d__2 = dlapy2_(&ritzr[j], &ritzi[j]);
@@ -659,14 +643,14 @@ L20:
         /* ritzr, ritzi and bound.                        */
         /* ---------------------------------------------- */
 
-        dsortc_(which, &c_true, &nconv, &ritzr[1], &ritzi[1], &bounds[1]);
+        dsortc_(which, &c_true, &nconv, ritzr, ritzi, bounds);
 
 #ifndef NO_TRACE
         if (msglvl > 1)
         {
-            dvout_(&kplusp, &ritzr[1], &debug_1.ndigit, "_naup2: Sorted float part of the eigenvalues");
-            dvout_(&kplusp, &ritzi[1], &debug_1.ndigit, "_naup2: Sorted imaginary part of the eigenvalues");
-            dvout_(&kplusp, &bounds[1], &debug_1.ndigit, "_naup2: Sorted ritz estimates.");
+            dvout_(&kplusp, ritzr, &debug_1.ndigit, "_naup2: Sorted float part of the eigenvalues");
+            dvout_(&kplusp, ritzi, &debug_1.ndigit, "_naup2: Sorted imaginary part of the eigenvalues");
+            dvout_(&kplusp, bounds, &debug_1.ndigit, "_naup2: Sorted ritz estimates.");
         }
 #endif
 
@@ -732,7 +716,7 @@ L20:
 
         if (nevbef < *nev)
         {
-            dngets_(ishift, which, nev, np, &ritzr[1], &ritzi[1], &bounds[1], &workl[1], &workl[*np + 1]);
+            dngets_(ishift, which, nev, np, ritzr, ritzi, bounds, workl, &workl[*np]);
         }
     }
 
@@ -745,9 +729,9 @@ L20:
             kp[0] = *nev;
             kp[1] = *np;
             ivout_(&c__2, kp, &debug_1.ndigit, "_naup2: NEV and NP are");
-            dvout_(nev, &ritzr[*np + 1], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values -- float part");
-            dvout_(nev, &ritzi[*np + 1], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values -- imag part");
-            dvout_(nev, &bounds[*np + 1], &debug_1.ndigit, "_naup2: Ritz estimates of the \"wanted\" values ");
+            dvout_(nev, &ritzr[*np], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values -- float part");
+            dvout_(nev, &ritzi[*np], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values -- imag part");
+            dvout_(nev, &bounds[*np], &debug_1.ndigit, "_naup2: Ritz estimates of the \"wanted\" values ");
         }
     }
 #endif
@@ -783,19 +767,19 @@ L50:
         /* for non-exact shift case.        */
         /* -------------------------------- */
 
-        dcopy_(np, &workl[1], &c__1, &ritzr[1], &c__1);
-        dcopy_(np, &workl[*np + 1], &c__1, &ritzi[1], &c__1);
+        dcopy_(np, workl, &c__1, ritzr, &c__1);
+        dcopy_(np, &workl[*np], &c__1, ritzi, &c__1);
     }
 
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
         ivout_(&c__1, np, &debug_1.ndigit, "_naup2: The number of shifts to apply ");
-        dvout_(np, &ritzr[1], &debug_1.ndigit, "_naup2: Real part of the shifts");
-        dvout_(np, &ritzi[1], &debug_1.ndigit, "_naup2: Imaginary part of the shifts");
+        dvout_(np, ritzr, &debug_1.ndigit, "_naup2: Real part of the shifts");
+        dvout_(np, ritzi, &debug_1.ndigit, "_naup2: Imaginary part of the shifts");
         if (*ishift == 1)
         {
-            dvout_(np, &bounds[1], &debug_1.ndigit, "_naup2: Ritz estimates of the shifts");
+            dvout_(np, bounds, &debug_1.ndigit, "_naup2: Ritz estimates of the shifts");
         }
     }
 #endif
@@ -807,7 +791,7 @@ L50:
     /* The first 2*N locations of WORKD are used as workspace. */
     /* ------------------------------------------------------- */
 
-    dnapps_(n, nev, np, &ritzr[1], &ritzi[1], &v[v_offset], ldv, &h[h_offset], ldh, &resid[1], &q[q_offset], ldq, &workl[1], &workd[1]);
+    dnapps_(n, nev, np, ritzr, ritzi, v, ldv, h, ldh, resid, q, ldq, workl, workd);
 
     /* ------------------------------------------- */
     /* Compute the B-norm of the updated residual. */
@@ -823,9 +807,10 @@ L50:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        dcopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        dcopy_(n, resid, &c__1, &workd[*n], &c__1);
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
 
         /* -------------------------------- */
@@ -836,7 +821,7 @@ L50:
     }
     else if (*bmat == 'I')
     {
-        dcopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        dcopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L100:
@@ -852,12 +837,12 @@ L100:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        rnorm = ddot_(n, &resid[1], &c__1, &workd[1], &c__1);
+        rnorm = ddot_(n, resid, &c__1, workd, &c__1);
         rnorm = sqrt((abs(rnorm)));
     }
     else if (*bmat == 'I')
     {
-        rnorm = dnrm2_(n, &resid[1], &c__1);
+        rnorm = dnrm2_(n, resid, &c__1);
     }
     cnorm = false;
 
@@ -865,7 +850,7 @@ L100:
     if (msglvl > 2)
     {
         dvout_(&c__1, &rnorm, &debug_1.ndigit, "_naup2: B-norm of residual for compressed factorization");
-        dmout_(nev, nev, &h[h_offset], ldh, &debug_1.ndigit, "_naup2: Compressed upper Hessenberg matrix H");
+        dmout_(nev, nev, h, ldh, &debug_1.ndigit, "_naup2: Compressed upper Hessenberg matrix H");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/dnaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/dnaup2.c
@@ -808,7 +808,7 @@ L50:
     {
         ++timing_1.nbx;
         dcopy_(n, resid, &c__1, &workd[*n], &c__1);
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;

--- a/src/ARPACK/arpack-ng/SRC/dnaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/dnaupd.c
@@ -569,7 +569,7 @@ int dnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 
         /* Computing 2nd power */
         i__1 = *ncv;
-        /* TODO: subtract 1 !!! */
+        /* TODO: ipntr index */
         ipntr[3] = 1 + iw + i__1 * i__1 + i__1 * 3;
         ipntr[4] = 1;
         ipntr[5] = 1 + ritzr;

--- a/src/ARPACK/arpack-ng/SRC/dnaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/dnaupd.c
@@ -413,7 +413,7 @@ int dnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 {
 
     /* System generated locals */
-    int v_offset, i__1, i__2;
+    int i__1, i__2;
 
     /* Local variables */
     int j, ierr;
@@ -424,21 +424,11 @@ int dnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 
     int ldh = *ncv;
     int ldq = *ncv;
-    int ih = 1;
-    int ritzr = ih + ldh * *ncv;
+    int ritzr =  ldh * *ncv;
     int ritzi = ritzr + *ncv;
     int bounds = ritzi + *ncv;
     int iq = bounds + *ncv;
     int iw = iq + ldq * *ncv;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    --iparam;
-    --ipntr;
-    --workl;
 
     /* Function Body */
     if (*ido == 0)
@@ -458,16 +448,16 @@ int dnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
         /* -------------- */
 
         ierr = 0;
-        ishift = iparam[1];
-        /*         levec  = iparam(2) */
-        mxiter = iparam[3];
-        /*         nb     = iparam(4) */
+        ishift = iparam[0];
+        /* levec  = iparam(2) */
+        mxiter = iparam[2];
+        /* nb     = iparam(4) */
 
         /* ------------------------------------------ */
         /* Revision 2 performs only implicit restart. */
         /* ------------------------------------------ */
 
-        mode = iparam[7];
+        mode = iparam[6];
 
         if (*n <= 0)
         {
@@ -554,7 +544,7 @@ int dnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
         /* Computing 2nd power */
         i__2 = *ncv;
         i__1 = i__2 * i__2 * 3 + *ncv * 6;
-        for (j = 1; j <= i__1; ++j)
+        for (j = 0; j < i__1; ++j)
         {
             workl[j] = 0.0;
         }
@@ -579,19 +569,20 @@ int dnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 
         /* Computing 2nd power */
         i__1 = *ncv;
-        ipntr[4] = iw + i__1 * i__1 + i__1 * 3;
-        ipntr[5] = ih;
-        ipntr[6] = ritzr;
-        ipntr[7] = ritzi;
-        ipntr[8] = bounds;
-        ipntr[14] = iw;
+        /* TODO: subtract 1 !!! */
+        ipntr[3] = 1 + iw + i__1 * i__1 + i__1 * 3;
+        ipntr[4] = 1;
+        ipntr[5] = 1 + ritzr;
+        ipntr[6] = 1 + ritzi;
+        ipntr[7] = 1 + bounds;
+        ipntr[13] = 1 + iw;
     }
 
     /* ----------------------------------------------------- */
     /* Carry out the Implicitly restarted Arnoldi Iteration. */
     /* ----------------------------------------------------- */
 
-    dnaup2_(ido, bmat, n, which, &nev0, &np, tol, &resid[1], &mode, &iupd, &ishift, &mxiter, &v[v_offset], ldv, &workl[ih], &ldh, &workl[ritzr], &workl[ritzi], &workl[bounds], &workl[iq], &ldq, &workl[iw], &ipntr[1], &workd[1], info);
+    dnaup2_(ido, bmat, n, which, &nev0, &np, tol, resid, &mode, &iupd, &ishift, &mxiter, v, ldv, workl, &ldh, &workl[ritzr], &workl[ritzi], &workl[bounds], &workl[iq], &ldq, &workl[iw], ipntr, workd, info);
 
     /* ------------------------------------------------ */
     /* ido .ne. 99 implies use of reverse communication */
@@ -600,18 +591,18 @@ int dnaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 
     if (*ido == 3)
     {
-        iparam[8] = np;
+        iparam[7] = np;
     }
     if (*ido != 99)
     {
         goto L9000;
     }
 
-    iparam[3] = mxiter;
-    iparam[5] = np;
-    iparam[9] = timing_1.nopx;
-    iparam[10] = timing_1.nbx;
-    iparam[11] = timing_1.nrorth;
+    iparam[2] = mxiter;
+    iparam[4] = np;
+    iparam[8] = timing_1.nopx;
+    iparam[9] = timing_1.nbx;
+    iparam[10] = timing_1.nrorth;
 
     /* ---------------------------------- */
     /* Exit if there was an informational */

--- a/src/ARPACK/arpack-ng/SRC/dneigh.c
+++ b/src/ARPACK/arpack-ng/SRC/dneigh.c
@@ -101,7 +101,7 @@ int dneigh_(double *rnorm, int *n, double *h,
             bounds, double *q, int *ldq, double *workl, int *ierr)
 {
     /* System generated locals */
-    int h_offset, q_dim, q_offset, i__1;
+    int q_dim, i__1;
     double d__1, d__2;
 
     /* Local variables */
@@ -112,22 +112,12 @@ int dneigh_(double *rnorm, int *n, double *h,
     bool select[1];
     int msglvl;
 
-
     /* ----------------------------- */
     /* Initialize timing statistics  */
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --workl;
-    --bounds;
-    --ritzi;
-    --ritzr;
-    h_offset = 1 + *ldh;
-    h -= h_offset;
     q_dim = *ldq;
-    q_offset = 1 + q_dim;
-    q -= q_offset;
 
     /* Function Body */
 #ifndef NO_TIMER
@@ -139,7 +129,7 @@ int dneigh_(double *rnorm, int *n, double *h,
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
-        dmout_(n, n, &h[h_offset], ldh, &debug_1.ndigit, "_neigh: Entering upper Hessenberg matrix H ");
+        dmout_(n, n, h, ldh, &debug_1.ndigit, "_neigh: Entering upper Hessenberg matrix H ");
     }
 #endif
 
@@ -151,14 +141,14 @@ int dneigh_(double *rnorm, int *n, double *h,
     /* and the last components of the Schur vectors in BOUNDS.   */
     /* --------------------------------------------------------- */
 
-    dlacpy_("A", n, n, &h[h_offset], ldh, &workl[1], n);
+    dlacpy_("A", n, n, h, ldh, workl, n);
     i__1 = *n - 1;
-    for (j = 1; j <= i__1; ++j)
+    for (j = 0; j < i__1; ++j)
     {
         bounds[j] = 0.0;
     }
-    bounds[*n] = 1.0;
-    dlahqr_(&c_true, &c_true, n, &c__1, n, &workl[1], n, &ritzr[1], &ritzi[1],&c__1, &c__1, &bounds[1], &c__1, ierr);
+    bounds[*n - 1] = 1.0;
+    dlahqr_(&c_true, &c_true, n, &c__1, n, workl, n, ritzr, ritzi,&c__1, &c__1, bounds, &c__1, ierr);
     if (*ierr != 0)
     {
         goto L9000;
@@ -167,7 +157,7 @@ int dneigh_(double *rnorm, int *n, double *h,
 #ifndef NO_TRACE
     if (msglvl > 1)
     {
-        dvout_(n, &bounds[1], &debug_1.ndigit, "_neigh: last row of the Schur matrix for H");
+        dvout_(n, bounds, &debug_1.ndigit, "_neigh: last row of the Schur matrix for H");
     }
 #endif
 
@@ -181,7 +171,7 @@ int dneigh_(double *rnorm, int *n, double *h,
     /* columns of Q.                                             */
     /* --------------------------------------------------------- */
 
-    dtrevc_("R", "A", select, n, &workl[1], n, vl, n, &q[q_offset], ldq, n, n,&workl[*n * *n + 1], ierr);
+    dtrevc_("R", "A", select, n, workl, n, vl, n, q, ldq, n, n,&workl[*n * *n], ierr);
 
     if (*ierr != 0)
     {
@@ -199,7 +189,7 @@ int dneigh_(double *rnorm, int *n, double *h,
 
     iconj = 0;
     i__1 = *n;
-    for (i = 1; i <= i__1; ++i)
+    for (i = 0; i < i__1; ++i)
     {
         if ((d__1 = ritzi[i], abs(d__1)) <= 0.0)
         {
@@ -207,9 +197,9 @@ int dneigh_(double *rnorm, int *n, double *h,
             /* Real eigenvalue case */
             /* -------------------- */
 
-            temp = dnrm2_(n, &q[i * q_dim + 1], &c__1);
+            temp = dnrm2_(n, &q[i * q_dim], &c__1);
             d__1 = 1.0 / temp;
-            dscal_(n, &d__1, &q[i * q_dim + 1], &c__1);
+            dscal_(n, &d__1, &q[i * q_dim], &c__1);
         }
         else
         {
@@ -223,13 +213,13 @@ int dneigh_(double *rnorm, int *n, double *h,
 
             if (iconj == 0)
             {
-                d__1 = dnrm2_(n, &q[i * q_dim + 1], &c__1);
-                d__2 = dnrm2_(n, &q[(i + 1) * q_dim + 1], &c__1);
+                d__1 = dnrm2_(n, &q[i * q_dim], &c__1);
+                d__2 = dnrm2_(n, &q[(i + 1) * q_dim], &c__1);
                 temp = dlapy2_(&d__1, &d__2);
                 d__1 = 1.0 / temp;
-                dscal_(n, &d__1, &q[i * q_dim + 1], &c__1);
+                dscal_(n, &d__1, &q[i * q_dim], &c__1);
                 d__1 = 1.0 / temp;
-                dscal_(n, &d__1, &q[(i + 1) * q_dim + 1], &c__1);
+                dscal_(n, &d__1, &q[(i + 1) * q_dim], &c__1);
                 iconj = 1;
             }
             else
@@ -239,12 +229,12 @@ int dneigh_(double *rnorm, int *n, double *h,
         }
     }
 
-    dgemv_("T", n, n, &d_one, &q[q_offset], ldq, &bounds[1], &c__1, &d_zero, &workl[1], &c__1);
+    dgemv_("T", n, n, &d_one, q, ldq, bounds, &c__1, &d_zero, workl, &c__1);
 
 #ifndef NO_TRACE
     if (msglvl > 1)
     {
-        dvout_(n, &workl[1], &debug_1.ndigit, "_neigh: Last row of the eigenvector matrix for H");
+        dvout_(n, workl, &debug_1.ndigit, "_neigh: Last row of the eigenvector matrix for H");
     }
 #endif
 
@@ -254,7 +244,7 @@ int dneigh_(double *rnorm, int *n, double *h,
 
     iconj = 0;
     i__1 = *n;
-    for (i = 1; i <= i__1; ++i)
+    for (i = 0; i < i__1; ++i)
     {
         if ((d__1 = ritzi[i], abs(d__1)) <= 0.0)
         {
@@ -290,9 +280,9 @@ int dneigh_(double *rnorm, int *n, double *h,
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
-        dvout_(n, &ritzr[1], &debug_1.ndigit, "_neigh: Real part of the eigenvalues of H");
-        dvout_(n, &ritzi[1], &debug_1.ndigit, "_neigh: Imaginary part of the eigenvalues of H");
-        dvout_(n, &bounds[1], &debug_1.ndigit, "_neigh: Ritz estimates for the eigenvalues of H");
+        dvout_(n, ritzr, &debug_1.ndigit, "_neigh: Real part of the eigenvalues of H");
+        dvout_(n, ritzi, &debug_1.ndigit, "_neigh: Imaginary part of the eigenvalues of H");
+        dvout_(n, bounds, &debug_1.ndigit, "_neigh: Ritz estimates for the eigenvalues of H");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/dneupd.c
+++ b/src/ARPACK/arpack-ng/SRC/dneupd.c
@@ -321,8 +321,7 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
     double vl[1]	/* was [1][1] */;
     int ibd, ldh, ldq, iri;
     double sep;
-    int irr, wri, wrr;
-    int mode;
+    int irr, wri, wrr, mode;
     double eps23;
     int ierr;
     double temp;
@@ -338,29 +337,21 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
     int ritzi;
     int ritzr;
     int nconv2;
-    int iheigi, iheigr, bounds, invsub, iuptri, msglvl, outncv, ishift,
-            numcnv;
+    int iheigi, iheigr, bounds, invsub, iuptri, msglvl, outncv, ishift, numcnv;
 
 
     /* Parameter adjustments */
     z_offset = 1 + *ldz;
     z -= z_offset;
-    --workd;
-    --resid;
-    --di;
-    --dr;
-    --workev;
-    --select;
     v_offset = 1 + *ldv;
     v -= v_offset;
-    --iparam;
-    --ipntr;
+    --select;
     --workl;
 
     /* Function Body */
     msglvl = debug_1.mneupd;
-    mode = iparam[7];
-    nconv = iparam[5];
+    mode = iparam[6];
+    nconv = iparam[4];
     *info = 0;
 
     /* ------------------------------- */
@@ -482,10 +473,10 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
     /* GRAND total of NCV * ( 3 * NCV + 6 ) locations.           */
     /* --------------------------------------------------------- */
 
-    ih = ipntr[5];
-    ritzr = ipntr[6];
-    ritzi = ipntr[7];
-    bounds = ipntr[8];
+    ih = ipntr[4];
+    ritzr = ipntr[5];
+    ritzi = ipntr[6];
+    bounds = ipntr[7];
     ldh = *ncv;
     ldq = *ncv;
     iheigr = bounds + ldh;
@@ -493,11 +484,11 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
     ihbds = iheigi + ldh;
     iuptri = ihbds + ldh;
     invsub = iuptri + ldh * *ncv;
-    ipntr[9] = iheigr;
-    ipntr[10] = iheigi;
-    ipntr[11] = ihbds;
-    ipntr[12] = iuptri;
-    ipntr[13] = invsub;
+    ipntr[8] = iheigr;
+    ipntr[9] = iheigi;
+    ipntr[10] = ihbds;
+    ipntr[11] = iuptri;
+    ipntr[12] = invsub;
     wrr = 1;
     wri = *ncv + 1;
     iwev = wri + *ncv;
@@ -514,7 +505,7 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
     /*     _naup2.                             */
     /* --------------------------------------- */
 
-    irr = ipntr[14] + *ncv * *ncv;
+    irr = ipntr[13] + *ncv * *ncv;
     iri = irr + *ncv;
     ibd = iri + *ncv;
 
@@ -698,8 +689,8 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
 
         if (strcmp(type, "REGULR") == 0)
         {
-            dcopy_(&nconv, &workl[iheigr], &c__1, &dr[1], &c__1);
-            dcopy_(&nconv, &workl[iheigi], &c__1, &di[1], &c__1);
+            dcopy_(&nconv, &workl[iheigr], &c__1, dr, &c__1);
+            dcopy_(&nconv, &workl[iheigi], &c__1, di, &c__1);
         }
 
         /* -------------------------------------------------------- */
@@ -708,7 +699,7 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
         /* columns of workl(invsub,ldq).                            */
         /* -------------------------------------------------------- */
 
-        dgeqr2_(ncv, &nconv, &workl[invsub], &ldq, &workev[1], &workev[*ncv + 1], &ierr);
+        dgeqr2_(ncv, &nconv, &workl[invsub], &ldq, workev, &workev[*ncv], &ierr);
 
         /* ------------------------------------------------------- */
         /* * Postmultiply V by Q using dorm2r .                    */
@@ -722,7 +713,7 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
         /* matrix of order NCONV in workl(iuptri)                  */
         /* ------------------------------------------------------- */
 
-        dorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, &workev[1], &v[v_offset], ldv, &workd[*n + 1], &ierr);
+        dorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &v[v_offset], ldv, &workd[*n], &ierr);
         dlacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
 
         for (j = 1; j <= nconv; ++j)
@@ -763,7 +754,7 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
                 }
             }
 
-            dtrevc_("R", "S", &select[1], ncv, &workl[iuptri], &ldq, vl, &c__1, &workl[invsub], &ldq, ncv, &outncv, &workev[1],&ierr);
+            dtrevc_("R", "S", &select[1], ncv, &workl[iuptri], &ldq, vl, &c__1, &workl[invsub], &ldq, ncv, &outncv, workev,&ierr);
 
             if (ierr != 0)
             {
@@ -780,10 +771,9 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
             /* ---------------------------------------------- */
 
             iconj = 0;
-            i__1 = nconv;
-            for (j = 1; j <= i__1; ++j)
+            for (j = 1; j <= nconv; ++j)
             {
-                if (workl[iheigi + j - 1] == 0.0)
+                if (workl[iheigi + j] == 0.0)
                 {
                     /* -------------------- */
                     /* real eigenvalue case */
@@ -821,12 +811,12 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
                 }
             }
 
-            dgemv_("T", ncv, &nconv, &d_one, &workl[invsub], &ldq, &workl[ihbds], &c__1, &d_zero, &workev[1], &c__1);
+            dgemv_("T", ncv, &nconv, &d_one, &workl[invsub], &ldq, &workl[ihbds], &c__1, &d_zero, workev, &c__1);
 
             iconj = 0;
-            for (j = 1; j <= nconv; ++j)
+            for (j = 0; j < nconv; ++j)
             {
-                if (workl[iheigi + j - 1] != 0.0)
+                if (workl[iheigi + j] != 0.0)
                 {
                     /* ----------------------------------------- */
                     /* Complex conjugate pair case. Note that    */
@@ -863,7 +853,7 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
             /* Copy Ritz estimates into workl(ihbds) */
             /* ------------------------------------- */
 
-            dcopy_(&nconv, &workev[1], &c__1, &workl[ihbds], &c__1);
+            dcopy_(&nconv, workev, &c__1, &workl[ihbds], &c__1);
 
             /* ------------------------------------------------------- */
             /* Compute the QR factorization of the eigenvector matrix  */
@@ -871,7 +861,7 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
             /* columns of workl(invsub,ldq).                           */
             /* ------------------------------------------------------- */
 
-            dgeqr2_(ncv, &nconv, &workl[invsub], &ldq, &workev[1], &workev[*ncv + 1], &ierr);
+            dgeqr2_(ncv, &nconv, &workl[invsub], &ldq, workev, &workev[*ncv], &ierr);
 
             /* -------------------------------------------- */
             /* * Postmultiply Z by Q.                       */
@@ -881,19 +871,19 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
             /* in workl(iheigr) and workl(iheigi).          */
             /* -------------------------------------------- */
 
-            dorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, &workev[1], &z[z_offset], ldz, &workd[*n + 1], &ierr);
+            dorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &z[z_offset], ldz, &workd[*n], &ierr);
             dtrmm_("R", "U", "N", "N", n, &nconv, &d_one, &workl[invsub], &ldq, &z[z_offset], ldz);
         }
     }
     else
     {
-        /* ----------------------------------------------------- */
-        /* An approximate invariant subspace is not needed.      */
-        /* Place the Ritz values computed DNAUPD  into DR and DI */
-        /* ----------------------------------------------------- */
+        /* ---------------------------------------------------- */
+        /* An approximate invariant subspace is not needed.     */
+        /* Place the Ritz values computed DNAUPD into DR and DI */
+        /* ---------------------------------------------------- */
 
-        dcopy_(&nconv, &workl[ritzr], &c__1, &dr[1], &c__1);
-        dcopy_(&nconv, &workl[ritzi], &c__1, &di[1], &c__1);
+        dcopy_(&nconv, &workl[ritzr], &c__1, dr, &c__1);
+        dcopy_(&nconv, &workl[ritzi], &c__1, di, &c__1);
         dcopy_(&nconv, &workl[ritzr], &c__1, &workl[iheigr], &c__1);
         dcopy_(&nconv, &workl[ritzi], &c__1, &workl[iheigi], &c__1);
         dcopy_(&nconv, &workl[bounds], &c__1, &workl[ihbds], &c__1);
@@ -928,24 +918,24 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
             }
 
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
-                temp = dlapy2_(&workl[iheigr + k - 1], &workl[iheigi + k - 1]);
-                d__1 = workl[ihbds + k - 1];
-                workl[ihbds + k - 1] = abs(d__1) / temp / temp;
+                temp = dlapy2_(&workl[iheigr + k], &workl[iheigi + k]);
+                d__1 = workl[ihbds + k];
+                workl[ihbds + k] = abs(d__1) / temp / temp;
             }
         }
         else if (strcmp(type, "REALPT") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
             }
         }
         else if (strcmp(type, "IMAGPT") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
             }
         }
@@ -963,36 +953,35 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
         if (strcmp(type, "SHIFTI") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
-                temp = dlapy2_(&workl[iheigr + k - 1], &workl[iheigi + k - 1]);
-                workl[iheigr + k - 1] = workl[iheigr + k - 1] / temp / temp + *sigmar;
-                workl[iheigi + k - 1] = -workl[iheigi + k - 1] / temp / temp + *sigmai;
+                temp = dlapy2_(&workl[iheigr + k], &workl[iheigi + k]);
+                workl[iheigr + k] = workl[iheigr + k] / temp / temp + *sigmar;
+                workl[iheigi + k] = -workl[iheigi + k] / temp / temp + *sigmai;
             }
 
-            dcopy_(&nconv, &workl[iheigr], &c__1, &dr[1], &c__1);
-            dcopy_(&nconv, &workl[iheigi], &c__1, &di[1], &c__1);
+            dcopy_(&nconv, &workl[iheigr], &c__1, dr, &c__1);
+            dcopy_(&nconv, &workl[iheigi], &c__1, di, &c__1);
 
         }
-        else if (strcmp(type, "REALPT") == 0 ||
-                 strcmp(type, "IMAGPT") == 0)
+        else if (strcmp(type, "REALPT") == 0 || strcmp(type, "IMAGPT") == 0)
         {
-            dcopy_(&nconv, &workl[iheigr], &c__1, &dr[1], &c__1);
-            dcopy_(&nconv, &workl[iheigi], &c__1, &di[1], &c__1);
+            dcopy_(&nconv, &workl[iheigr], &c__1, dr, &c__1);
+            dcopy_(&nconv, &workl[iheigi], &c__1, di, &c__1);
         }
     }
 
 #ifndef NO_TRACE
     if (msglvl > 1 && strcmp(type, "SHIFTI") == 0)
     {
-        dvout_(&nconv, &dr[1], &debug_1.ndigit, "_neupd: Untransformed float part of the Ritz valuess.");
-        dvout_(&nconv, &di[1], &debug_1.ndigit, "_neupd: Untransformed imag part of the Ritz valuess.");
+        dvout_(&nconv, dr, &debug_1.ndigit, "_neupd: Untransformed float part of the Ritz valuess.");
+        dvout_(&nconv, di, &debug_1.ndigit, "_neupd: Untransformed imag part of the Ritz valuess.");
         dvout_(&nconv, &workl[ihbds], &debug_1.ndigit, "_neupd: Ritz estimates of untransformed Ritz values.");
     }
     else if (msglvl > 1 && strcmp(type, "REGULR") == 0)
     {
-        dvout_(&nconv, &dr[1], &debug_1.ndigit, "_neupd: Real parts of converged Ritz values.");
-        dvout_(&nconv, &di[1], &debug_1.ndigit, "_neupd: Imag parts of converged Ritz values.");
+        dvout_(&nconv, dr, &debug_1.ndigit, "_neupd: Real parts of converged Ritz values.");
+        dvout_(&nconv, di, &debug_1.ndigit, "_neupd: Imag parts of converged Ritz values.");
         dvout_(&nconv, &workl[ihbds], &debug_1.ndigit, "_neupd: Associated Ritz estimates.");
     }
 #endif
@@ -1017,19 +1006,19 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
         /* ---------------------------------------------- */
 
         iconj = 0;
-        for (j = 1; j <= nconv; ++j)
+        for (j = 0; j < nconv; ++j)
         {
-            if (workl[iheigi + j - 1] == 0.0 && workl[iheigr + j - 1] != 0.0)
+            if (workl[iheigi + j] == 0.0 && workl[iheigr + j] != 0.0)
             {
-                workev[j] = workl[invsub + (j - 1) * ldq + *ncv - 1] / workl[iheigr + j - 1];
+                workev[j] = workl[invsub + j * ldq + *ncv - 1] / workl[iheigr + j];
             }
             else if (iconj == 0)
             {
-                temp = dlapy2_(&workl[iheigr + j - 1], &workl[iheigi + j - 1]);
+                temp = dlapy2_(&workl[iheigr + j], &workl[iheigi + j]);
                 if (temp != 0.0)
                 {
-                    workev[j] = (workl[invsub + (j - 1) * ldq + *ncv - 1] * workl[iheigr + j - 1] + workl[invsub + j * ldq + * ncv - 1] * workl[iheigi + j - 1]) / temp / temp;
-                    workev[j + 1] = (workl[invsub + j * ldq + *ncv - 1] * workl[iheigr + j - 1] - workl[invsub + (j - 1) * ldq + *ncv - 1] * workl[iheigi + j - 1]) / temp / temp;
+                    workev[j] = (workl[invsub + j * ldq + *ncv - 1] * workl[iheigr + j] + workl[invsub + (j + 1) * ldq + *ncv - 1] * workl[iheigi + j]) / temp / temp;
+                    workev[j + 1] = (workl[invsub + (j + 1) * ldq + *ncv - 1] * workl[iheigr + j] - workl[invsub + j * ldq + *ncv - 1] * workl[iheigi + j]) / temp / temp;
                 }
                 iconj = 1;
             }
@@ -1045,7 +1034,7 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
         /* purify all the Ritz vectors together. */
         /* ------------------------------------- */
 
-        dger_(n, &nconv, &d_one, &resid[1], &c__1, &workev[1], &c__1, &z[z_offset], ldz);
+        dger_(n, &nconv, &d_one, resid, &c__1, workev, &c__1, &z[z_offset], ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/dneupd.c
+++ b/src/ARPACK/arpack-ng/SRC/dneupd.c
@@ -312,7 +312,7 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
             int *lworkl, int *info)
 {
     /* System generated locals */
-    int v_offset, z_offset, i__1;
+    int i__1;
     double d__1, d__2;
 
     /* Builtin functions */
@@ -341,10 +341,6 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
 
 
     /* Parameter adjustments */
-    z_offset = 1 + *ldz;
-    z -= z_offset;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
     --select;
     --workl;
 
@@ -713,8 +709,8 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
         /* matrix of order NCONV in workl(iuptri)                  */
         /* ------------------------------------------------------- */
 
-        dorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &v[v_offset], ldv, &workd[*n], &ierr);
-        dlacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
+        dorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, v, ldv, &workd[*n], &ierr);
+        dlacpy_("A", n, &nconv, v, ldv, z, ldz);
 
         for (j = 1; j <= nconv; ++j)
         {
@@ -871,8 +867,8 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
             /* in workl(iheigr) and workl(iheigi).          */
             /* -------------------------------------------- */
 
-            dorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &z[z_offset], ldz, &workd[*n], &ierr);
-            dtrmm_("R", "U", "N", "N", n, &nconv, &d_one, &workl[invsub], &ldq, &z[z_offset], ldz);
+            dorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, z, ldz, &workd[*n], &ierr);
+            dtrmm_("R", "U", "N", "N", n, &nconv, &d_one, &workl[invsub], &ldq, z, ldz);
         }
     }
     else
@@ -1034,7 +1030,7 @@ int dneupd_(bool *rvec, char *howmny, bool *select, double *dr, double *di, doub
         /* purify all the Ritz vectors together. */
         /* ------------------------------------- */
 
-        dger_(n, &nconv, &d_one, resid, &c__1, workev, &c__1, &z[z_offset], ldz);
+        dger_(n, &nconv, &d_one, resid, &c__1, workev, &c__1, z, ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/dngets.c
+++ b/src/ARPACK/arpack-ng/SRC/dngets.c
@@ -107,11 +107,6 @@ int dngets_(int *ishift, char *which, int *kev, int *np, double *ritzr,
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --bounds;
-    --ritzi;
-    --ritzr;
-
     /* Function Body */
 #ifndef NO_TIMER
     arscnd_(&t0);
@@ -133,30 +128,30 @@ int dngets_(int *ishift, char *which, int *kev, int *np, double *ritzr,
 
     if (strcmp(which, "LM") == 0)
     {
-        dsortc_("LR", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        dsortc_("LR", &c_true, &i__1, ritzr, ritzi, bounds);
     }
     else if (strcmp(which, "SM") == 0)
     {
-        dsortc_("SR", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        dsortc_("SR", &c_true, &i__1, ritzr, ritzi, bounds);
     }
     else if (strcmp(which, "LR") == 0)
     {
-        dsortc_("LM", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        dsortc_("LM", &c_true, &i__1, ritzr, ritzi, bounds);
     }
     else if (strcmp(which, "SR") == 0)
     {
-        dsortc_("SM", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        dsortc_("SM", &c_true, &i__1, ritzr, ritzi, bounds);
     }
     else if (strcmp(which, "LI") == 0)
     {
-        dsortc_("LM", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        dsortc_("LM", &c_true, &i__1, ritzr, ritzi, bounds);
     }
     else if (strcmp(which, "SI") == 0)
     {
-        dsortc_("SM", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        dsortc_("SM", &c_true, &i__1, ritzr, ritzi, bounds);
     }
 
-    dsortc_(which, &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+    dsortc_(which, &c_true, &i__1, ritzr, ritzi, bounds);
 
     /* ----------------------------------------------------- */
     /* Increase KEV by one if the ( ritzr(np),ritzi(np) )    */
@@ -165,7 +160,7 @@ int dngets_(int *ishift, char *which, int *kev, int *np, double *ritzr,
     /* complex conjugate pairs together.                     */
     /* ----------------------------------------------------- */
 
-    if (ritzr[*np + 1] - ritzr[*np] == 0.0 && ritzi[*np + 1] + ritzi[*np] == 0.0)
+    if (ritzr[*np] - ritzr[*np - 1] == 0.0 && ritzi[*np] + ritzi[*np - 1] == 0.0)
     {
         --(*np);
         ++(*kev);
@@ -182,7 +177,7 @@ int dngets_(int *ishift, char *which, int *kev, int *np, double *ritzr,
         /* Be careful and use 'SR' since we want to sort BOUNDS! */
         /* ----------------------------------------------------- */
 
-        dsortc_("SR", &c_true, np, &bounds[1], &ritzr[1], &ritzi[1]);
+        dsortc_("SR", &c_true, np, bounds, ritzr, ritzi);
     }
 
 #ifndef NO_TIMER
@@ -196,9 +191,9 @@ int dngets_(int *ishift, char *which, int *kev, int *np, double *ritzr,
         i__1 = *kev + *np;
         ivout_(&c__1, kev, &debug_1.ndigit, "_ngets: KEV is");
         ivout_(&c__1, np, &debug_1.ndigit, "_ngets: NP is");
-        dvout_(&i__1, &ritzr[1], &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix -- float part");
-        dvout_(&i__1, &ritzi[1], &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix -- imag part");
-        dvout_(&i__1, &bounds[1], &debug_1.ndigit, "_ngets: Ritz estimates of the current KEV+NP Ritz values");
+        dvout_(&i__1, ritzr, &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix -- float part");
+        dvout_(&i__1, ritzi, &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix -- imag part");
+        dvout_(&i__1, bounds, &debug_1.ndigit, "_ngets: Ritz estimates of the current KEV+NP Ritz values");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/dsapps.c
+++ b/src/ARPACK/arpack-ng/SRC/dsapps.c
@@ -154,9 +154,6 @@ int dsapps_(int *n, int *kev, int *np,
     int istart, kplusp, msglvl;
 
     /* Parameter adjustments */
-    --workd;
-    --resid;
-    --shift;
     v_dim = *ldv;
     v_offset = 1 + v_dim;
     v -= v_offset;
@@ -265,7 +262,8 @@ L40:
             /* that attempts to drive h(istart+1,1) to zero.          */
             /* ------------------------------------------------------ */
 
-            f = h[istart + (h_dim << 1)] - shift[jj];
+            /* TODO: fix jj - 1 */
+            f = h[istart + (h_dim << 1)] - shift[jj - 1];
             g = h[istart + 1 + h_dim];
             dlartg_(&f, &g, &c, &s, &r);
 
@@ -460,7 +458,7 @@ L90:
 
     if (h[*kev + 1 + h_dim] > 0.0)
     {
-        dgemv_("N", n, &kplusp, &d_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &d_zero, &workd[*n + 1], &c__1);
+        dgemv_("N", n, &kplusp, &d_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &d_zero, &workd[*n], &c__1);
     }
 
     /* ----------------------------------------------------- */
@@ -474,8 +472,8 @@ L90:
     for (i = 1; i <= i__1; ++i)
     {
         i__2 = kplusp - i + 1;
-        dgemv_("N", n, &i__2, &d_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &d_zero, &workd[1], &c__1);
-        dcopy_(n, &workd[1], &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
+        dgemv_("N", n, &i__2, &d_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &d_zero, workd, &c__1);
+        dcopy_(n, workd, &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------------------- */
@@ -495,7 +493,7 @@ L90:
 
     if (h[*kev + 1 + h_dim] > 0.0)
     {
-        dcopy_(n, &workd[*n + 1], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
+        dcopy_(n, &workd[*n], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------- */
@@ -506,10 +504,10 @@ L90:
     /*    betak = e_{kev+1}'*H*e_{kev}     */
     /* ----------------------------------- */
 
-    dscal_(n, &q[kplusp + *kev * q_dim], &resid[1], &c__1);
+    dscal_(n, &q[kplusp + *kev * q_dim], resid, &c__1);
     if (h[*kev + 1 + h_dim] > 0.0)
     {
-        daxpy_(n, &h[*kev + 1 + h_dim], &v[(*kev + 1) * v_dim + 1], &c__1,&resid[1], &c__1);
+        daxpy_(n, &h[*kev + 1 + h_dim], &v[(*kev + 1) * v_dim + 1], &c__1,resid, &c__1);
     }
 
 #ifndef NO_TRACE

--- a/src/ARPACK/arpack-ng/SRC/dsaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/dsaup2.c
@@ -792,7 +792,7 @@ L50:
     {
         ++timing_1.nbx;
         dcopy_(n, resid, &c__1, &workd[*n], &c__1);
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;

--- a/src/ARPACK/arpack-ng/SRC/dsaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/dsaupd.c
@@ -413,7 +413,7 @@ int dsaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 {
 
     /* System generated locals */
-    int v_offset, i__1, i__2;
+    int i__1, i__2;
 
     /* Local variables */
     int j, ierr;
@@ -424,20 +424,10 @@ int dsaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 
     int ldh = *ncv;
     int ldq = *ncv;
-    int ih = 1;
-    int ritz = ih + (ldh << 1);
+    int ritz = ldh << 1;
     int bounds = ritz + *ncv;
     int iq = bounds + *ncv;
     int iw = iq + *ncv * *ncv;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    --iparam;
-    --ipntr;
-    --workl;
 
     /* Function Body */
     if (*ido == 0)
@@ -453,15 +443,15 @@ int dsaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 #endif
 
         ierr = 0;
-        ishift = iparam[1];
-        mxiter = iparam[3];
-        /*         nb     = iparam(4) */
+        ishift = iparam[0];
+        mxiter = iparam[2];
+        /* nb     = iparam(4) */
 
         /* ------------------------------------------ */
         /* Revision 2 performs only implicit restart. */
         /* ------------------------------------------ */
 
-        mode = iparam[7];
+        mode = iparam[6];
 
         /* -------------- */
         /* Error checking */
@@ -562,7 +552,7 @@ int dsaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
         /* Computing 2nd power */
         i__2 = *ncv;
         i__1 = i__2 * i__2 + (*ncv << 3);
-        for (j = 1; j <= i__1; ++j)
+        for (j = 0; j < i__1; ++j)
         {
             workl[j] = 0.0;
         }
@@ -581,18 +571,19 @@ int dsaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 
 
         /* Computing 2nd power */
-        ipntr[4] = iw + *ncv * 3;
-        ipntr[5] = ih;
-        ipntr[6] = ritz;
-        ipntr[7] = bounds;
-        ipntr[11] = iw;
+        /* TODO: subtract 1 !!! */
+        ipntr[3] = 1 + iw + *ncv * 3;
+        ipntr[4] = 1;
+        ipntr[5] = 1 + ritz;
+        ipntr[6] = 1 + bounds;
+        ipntr[10] = 1 + iw;
     }
 
     /* ----------------------------------------------------- */
     /* Carry out the Implicitly restarted Lanczos Iteration. */
     /* ----------------------------------------------------- */
 
-    dsaup2_(ido, bmat, n, which, &nev0, &np, tol, &resid[1], &mode, &iupd, &ishift, &mxiter, &v[v_offset], ldv, &workl[ih], &ldh, &workl[ritz], &workl[bounds], &workl[iq], &ldq, &workl[iw], &ipntr[1], &workd[1], info);
+    dsaup2_(ido, bmat, n, which, &nev0, &np, tol, resid, &mode, &iupd, &ishift, &mxiter, v, ldv, workl, &ldh, &workl[ritz], &workl[bounds], &workl[iq], &ldq, &workl[iw], ipntr, workd, info);
 
     /* ------------------------------------------------ */
     /* ido .ne. 99 implies use of reverse communication */
@@ -601,18 +592,18 @@ int dsaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 
     if (*ido == 3)
     {
-        iparam[8] = np;
+        iparam[7] = np;
     }
     if (*ido != 99)
     {
         goto L9000;
     }
 
-    iparam[3] = mxiter;
-    iparam[5] = np;
-    iparam[9] = timing_1.nopx;
-    iparam[10] = timing_1.nbx;
-    iparam[11] = timing_1.nrorth;
+    iparam[2] = mxiter;
+    iparam[4] = np;
+    iparam[8] = timing_1.nopx;
+    iparam[9] = timing_1.nbx;
+    iparam[10] = timing_1.nrorth;
 
     /* ---------------------------------- */
     /* Exit if there was an informational */

--- a/src/ARPACK/arpack-ng/SRC/dsaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/dsaupd.c
@@ -569,9 +569,7 @@ int dsaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
         /* workl(4*ncv+ncv*ncv+1:7*ncv+ncv*ncv) := workspace     */
         /* ----------------------------------------------------- */
 
-
-        /* Computing 2nd power */
-        /* TODO: subtract 1 !!! */
+        /* TODO: ipntr index */
         ipntr[3] = 1 + iw + *ncv * 3;
         ipntr[4] = 1;
         ipntr[5] = 1 + ritz;

--- a/src/ARPACK/arpack-ng/SRC/dseigt.c
+++ b/src/ARPACK/arpack-ng/SRC/dseigt.c
@@ -89,7 +89,7 @@ int dseigt_(double *rnorm, int *n, double *h,
             int *ierr)
 {
     /* System generated locals */
-    int h_dim, h_offset, i__1;
+    int h_dim, i__1;
     double d__1;
 
     /* Local variables */
@@ -97,20 +97,12 @@ int dseigt_(double *rnorm, int *n, double *h,
     static float t0, t1;
     int msglvl;
 
-
     /* ----------------------------- */
     /* Initialize timing statistics  */
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --workl;
-    --bounds;
-    --eig;
     h_dim = *ldh;
-    h_offset = 1 + h_dim;
-    h -= h_offset;
-
     /* Function Body */
 #ifndef NO_TIMER
     arscnd_(&t0);
@@ -121,19 +113,19 @@ int dseigt_(double *rnorm, int *n, double *h,
 #ifndef NO_TRACE
     if (msglvl > 0)
     {
-        dvout_(n, &h[(h_dim << 1) + 1], &debug_1.ndigit, "_seigt: main diagonal of matrix H");
+        dvout_(n, &h[h_dim], &debug_1.ndigit, "_seigt: main diagonal of matrix H");
         if (*n > 1)
         {
             i__1 = *n - 1;
-            dvout_(&i__1, &h[h_dim + 2], &debug_1.ndigit, "_seigt: sub diagonal of matrix H");
+            dvout_(&i__1, &h[1], &debug_1.ndigit, "_seigt: sub diagonal of matrix H");
         }
     }
 #endif
 
-    dcopy_(n, &h[(h_dim << 1) + 1], &c__1, &eig[1], &c__1);
+    dcopy_(n, &h[h_dim], &c__1, eig, &c__1);
     i__1 = *n - 1;
-    dcopy_(&i__1, &h[h_dim + 2], &c__1, &workl[1], &c__1);
-    dstqrb_(n, &eig[1], &workl[1], &bounds[1], &workl[*n + 1], ierr);
+    dcopy_(&i__1, &h[1], &c__1, workl, &c__1);
+    dstqrb_(n, eig, workl, bounds, &workl[*n], ierr);
     if (*ierr != 0)
     {
         goto L9000;
@@ -141,7 +133,7 @@ int dseigt_(double *rnorm, int *n, double *h,
 #ifndef NO_TRACE
     if (msglvl > 1)
     {
-        dvout_(n, &bounds[1], &debug_1.ndigit, "_seigt: last row of the eigenvector matrix for H");
+        dvout_(n, bounds, &debug_1.ndigit, "_seigt: last row of the eigenvector matrix for H");
     }
 #endif
 
@@ -151,7 +143,7 @@ int dseigt_(double *rnorm, int *n, double *h,
     /* --------------------------------------------- */
 
     i__1 = *n;
-    for (k = 1; k <= i__1; ++k)
+    for (k = 0; k < i__1; ++k)
     {
         bounds[k] = *rnorm * (d__1 = bounds[k], abs(d__1));
     }

--- a/src/ARPACK/arpack-ng/SRC/dseupd.c
+++ b/src/ARPACK/arpack-ng/SRC/dseupd.c
@@ -249,22 +249,17 @@ int dseupd_(bool *rvec, char *howmny, bool *select, double *d, double *z, int *l
 
 
     /* Parameter adjustments */
-    --workd;
-    --resid;
     z_offset = 1 + *ldz;
     z -= z_offset;
-    --d;
-    --select;
     v_offset = 1 + *ldv;
     v -= v_offset;
-    --iparam;
-    --ipntr;
+    --select;
     --workl;
 
     /* Function Body */
     msglvl = debug_1.mseupd;
-    mode = iparam[7];
-    nconv = iparam[5];
+    mode = iparam[6];
+    nconv = iparam[4];
     *info = 0;
 
     /* ------------ */
@@ -400,9 +395,9 @@ int dseupd_(bool *rvec, char *howmny, bool *select, double *d, double *z, int *l
     /* GRAND total of NCV*(NCV+8) locations.                 */
     /* ----------------------------------------------------- */
 
-    ih = ipntr[5];
-    ritz = ipntr[6];
-    bounds = ipntr[7];
+    ih = ipntr[4];
+    ritz = ipntr[5];
+    bounds = ipntr[6];
     ldh = *ncv;
     ldq = *ncv;
     ihd = bounds + ldh;
@@ -410,10 +405,10 @@ int dseupd_(bool *rvec, char *howmny, bool *select, double *d, double *z, int *l
     iq = ihb + ldh;
     iw = iq + ldh * *ncv;
     next = iw + (*ncv << 1);
-    ipntr[4] = next;
-    ipntr[8] = ihd;
-    ipntr[9] = ihb;
-    ipntr[10] = iq;
+    ipntr[3] = next;
+    ipntr[7] = ihd;
+    ipntr[8] = ihb;
+    ipntr[9] = iq;
 
     /* -------------------------------------- */
     /* irz points to the Ritz values computed */
@@ -423,7 +418,7 @@ int dseupd_(bool *rvec, char *howmny, bool *select, double *d, double *z, int *l
     /*     _saup2.                            */
     /* -------------------------------------- */
 
-    irz = ipntr[11] + *ncv;
+    irz = ipntr[10] + *ncv;
     ibd = irz + *ncv;
 
     /* ------------------------------- */
@@ -447,7 +442,7 @@ int dseupd_(bool *rvec, char *howmny, bool *select, double *d, double *z, int *l
     }
     else if (*bmat == 'G')
     {
-        bnorm2 = dnrm2_(n, &workd[1], &c__1);
+        bnorm2 = dnrm2_(n, workd, &c__1);
     }
 
 #ifndef NO_TRACE
@@ -644,7 +639,7 @@ L30:
         /* Load the converged Ritz values into D. */
         /* -------------------------------------- */
 
-        dcopy_(&nconv, &workl[ihd], &c__1, &d[1], &c__1);
+        dcopy_(&nconv, &workl[ihd], &c__1, d, &c__1);
     }
     else
     {
@@ -652,7 +647,7 @@ L30:
         /* Ritz vectors not required. Load Ritz values into D. */
         /* --------------------------------------------------- */
 
-        dcopy_(&nconv, &workl[ritz], &c__1, &d[1], &c__1);
+        dcopy_(&nconv, &workl[ritz], &c__1, d, &c__1);
         dcopy_(ncv, &workl[ritz], &c__1, &workl[ihd], &c__1);
     }
 
@@ -671,7 +666,7 @@ L30:
 
         if (*rvec)
         {
-            dsesrt_("LA", rvec, &nconv, &d[1], ncv, &workl[iq], &ldq);
+            dsesrt_("LA", rvec, &nconv, d, ncv, &workl[iq], &ldq);
         }
         else
         {
@@ -699,25 +694,25 @@ L30:
         if (strcmp(type, "SHIFTI") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
-                workl[ihd + k - 1] = 1.0 / workl[ihd + k - 1] + *sigma;
+                workl[ihd + k] = 1.0 / workl[ihd + k] + *sigma;
             }
         }
         else if (strcmp(type, "BUCKLE") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
-                workl[ihd + k - 1] = *sigma * workl[ihd + k - 1] / (workl[ihd + k - 1] - 1.0);
+                workl[ihd + k] = *sigma * workl[ihd + k] / (workl[ihd + k] - 1.0);
             }
         }
         else if (strcmp(type, "CAYLEY") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
-                workl[ihd + k - 1] = *sigma * (workl[ihd + k - 1] + 1.0) / (workl[ihd + k - 1] - 1.0);
+                workl[ihd + k] = *sigma * (workl[ihd + k] + 1.0) / (workl[ihd + k] - 1.0);
             }
         }
 
@@ -736,18 +731,18 @@ L30:
         /*  Ritz vector purification.                                  */
         /* ----------------------------------------------------------- */
 
-        dcopy_(&nconv, &workl[ihd], &c__1, &d[1], &c__1);
+        dcopy_(&nconv, &workl[ihd], &c__1, d, &c__1);
         dsortr_("LA", &c_true, &nconv, &workl[ihd], &workl[iw]);
         if (*rvec)
         {
-            dsesrt_("LA", rvec, &nconv, &d[1], ncv, &workl[iq], &ldq);
+            dsesrt_("LA", rvec, &nconv, d, ncv, &workl[iq], &ldq);
         }
         else
         {
             dcopy_(ncv, &workl[bounds], &c__1, &workl[ihb], &c__1);
             d__1 = bnorm2 / rnorm;
             dscal_(ncv, &d__1, &workl[ihb], &c__1);
-            dsortr_("LA", &c_true, &nconv, &d[1], &workl[ihb]);
+            dsortr_("LA", &c_true, &nconv, d, &workl[ihb]);
         }
     }
 
@@ -775,7 +770,7 @@ L30:
         /* the Ritz values in workl(ihd).                         */
         /* ------------------------------------------------------ */
 
-        dorm2r_("R", "N", n, ncv, &nconv, &workl[iq], &ldq, &workl[iw + *ncv], &v[v_offset], ldv, &workd[*n + 1], &ierr);
+        dorm2r_("R", "N", n, ncv, &nconv, &workl[iq], &ldq, &workl[iw + *ncv], &v[v_offset], ldv, &workd[*n], &ierr);
         dlacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
 
         /* --------------------------------------------------- */
@@ -832,33 +827,33 @@ L30:
         if (strcmp(type, "SHIFTI") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
                 /* Computing 2nd power */
-                d__1 = workl[ihb + k - 1];
-                d__2 = workl[iw + k - 1];
-                workl[ihb + k - 1] = abs(d__1) / (d__2 * d__2);
+                d__1 = workl[ihb + k];
+                d__2 = workl[iw + k];
+                workl[ihb + k] = abs(d__1) / (d__2 * d__2);
             }
 
         }
         else if (strcmp(type, "BUCKLE") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
                 /* Computing 2nd power */
-                d__1 = workl[ihb + k - 1];
-                d__2 = workl[iw + k - 1] - 1.0;
-                workl[ihb + k - 1] = *sigma * abs(d__1) / (d__2 * d__2);
+                d__1 = workl[ihb + k];
+                d__2 = workl[iw + k] - 1.0;
+                workl[ihb + k] = *sigma * abs(d__1) / (d__2 * d__2);
             }
         }
         else if (strcmp(type, "CAYLEY") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
-                d__1 = workl[ihb + k - 1] / workl[iw + k - 1] * (workl[iw + k - 1] - 1.0);
-                workl[ihb + k - 1] = abs(d__1);
+                d__1 = workl[ihb + k] / workl[iw + k] * (workl[iw + k] - 1.0);
+                workl[ihb + k] = abs(d__1);
             }
         }
     }
@@ -866,12 +861,12 @@ L30:
 #ifndef NO_TRACE
     if (msglvl > 1 && strcmp(type, "REGULR") != 0)
     {
-        dvout_(&nconv, &d[1], &debug_1.ndigit, "_seupd: Untransformed converged Ritz values");
+        dvout_(&nconv, d, &debug_1.ndigit, "_seupd: Untransformed converged Ritz values");
         dvout_(&nconv, &workl[ihb], &debug_1.ndigit, "_seupd: Ritz estimates of the untransformed Ritz values");
     }
     else if (msglvl > 1)
     {
-        dvout_(&nconv, &d[1], &debug_1.ndigit, "_seupd: Converged Ritz values");
+        dvout_(&nconv, d, &debug_1.ndigit, "_seupd: Converged Ritz values");
         dvout_(&nconv, &workl[ihb], &debug_1.ndigit, "_seupd: Associated Ritz estimates");
     }
 #endif
@@ -901,7 +896,7 @@ L30:
 
     if (*rvec && strcmp(type, "REGULR") != 0)
     {
-        dger_(n, &nconv, &d_one, &resid[1], &c__1, &workl[iw], &c__1, &z[z_offset], ldz);
+        dger_(n, &nconv, &d_one, resid, &c__1, &workl[iw], &c__1, &z[z_offset], ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/dseupd.c
+++ b/src/ARPACK/arpack-ng/SRC/dseupd.c
@@ -225,7 +225,7 @@ int dseupd_(bool *rvec, char *howmny, bool *select, double *d, double *z, int *l
             double *workd, double *workl, int *lworkl, int *info)
 {
     /* System generated locals */
-    int v_offset, z_offset, i__1;
+    int i__1;
     double d__1, d__2, d__3;
 
     /* Builtin functions */
@@ -249,10 +249,6 @@ int dseupd_(bool *rvec, char *howmny, bool *select, double *d, double *z, int *l
 
 
     /* Parameter adjustments */
-    z_offset = 1 + *ldz;
-    z -= z_offset;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
     --select;
     --workl;
 
@@ -770,8 +766,8 @@ L30:
         /* the Ritz values in workl(ihd).                         */
         /* ------------------------------------------------------ */
 
-        dorm2r_("R", "N", n, ncv, &nconv, &workl[iq], &ldq, &workl[iw + *ncv], &v[v_offset], ldv, &workd[*n], &ierr);
-        dlacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
+        dorm2r_("R", "N", n, ncv, &nconv, &workl[iq], &ldq, &workl[iw + *ncv], v, ldv, &workd[*n], &ierr);
+        dlacpy_("A", n, &nconv, v, ldv, z, ldz);
 
         /* --------------------------------------------------- */
         /* In order to compute the Ritz estimates for the Ritz */
@@ -896,7 +892,7 @@ L30:
 
     if (*rvec && strcmp(type, "REGULR") != 0)
     {
-        dger_(n, &nconv, &d_one, resid, &c__1, &workl[iw], &c__1, &z[z_offset], ldz);
+        dger_(n, &nconv, &d_one, resid, &c__1, &workl[iw], &c__1, z, ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/dsgets.c
+++ b/src/ARPACK/arpack-ng/SRC/dsgets.c
@@ -107,11 +107,6 @@ int dsgets_(int *ishift, char *which, int *kev, int *np, double *ritz,
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --shifts;
-    --bounds;
-    --ritz;
-
     /* Function Body */
 #ifndef NO_TIMER
     arscnd_(&t0);
@@ -131,13 +126,13 @@ int dsgets_(int *ishift, char *which, int *kev, int *np, double *ritz,
         /* --------------------------------------------------- */
 
         i__1 = *kev + *np;
-        dsortr_("LA", &c_true, &i__1, &ritz[1], &bounds[1]);
+        dsortr_("LA", &c_true, &i__1, ritz, bounds);
         kevd2 = *kev / 2;
         if (*kev > 1)
         {
             i__1 = min(kevd2,*np);
-            dswap_(&i__1, &ritz[1], &c__1, &ritz[max(kevd2,*np) + 1], &c__1);
-            dswap_(&i__1, &bounds[1], &c__1, &bounds[max(kevd2,*np) + 1], &c__1);
+            dswap_(&i__1, ritz, &c__1, &ritz[max(kevd2,*np)], &c__1);
+            dswap_(&i__1, bounds, &c__1, &bounds[max(kevd2,*np)], &c__1);
         }
     }
     else
@@ -151,7 +146,7 @@ int dsgets_(int *ishift, char *which, int *kev, int *np, double *ritz,
         /* -------------------------------------------------- */
 
         i__1 = *kev + *np;
-        dsortr_(which, &c_true, &i__1, &ritz[1], &bounds[1]);
+        dsortr_(which, &c_true, &i__1, ritz, bounds);
     }
 
     if (*ishift == 1 && *np > 0)
@@ -164,8 +159,8 @@ int dsgets_(int *ishift, char *which, int *kev, int *np, double *ritz,
         /* are applied in subroutine dsapps.                     */
         /* ----------------------------------------------------- */
 
-        dsortr_("SM", &c_true, np, &bounds[1], &ritz[1]);
-        dcopy_(np, &ritz[1], &c__1, &shifts[1], &c__1);
+        dsortr_("SM", &c_true, np, bounds, ritz);
+        dcopy_(np, ritz, &c__1, shifts, &c__1);
     }
 
 #ifndef NO_TIMER
@@ -179,8 +174,8 @@ int dsgets_(int *ishift, char *which, int *kev, int *np, double *ritz,
         i__1 = *kev + *np;
         ivout_(&c__1, kev, &debug_1.ndigit, "_sgets: KEV is");
         ivout_(&c__1, np, &debug_1.ndigit, "_sgets: NP is");
-        dvout_(&i__1, &ritz[1], &debug_1.ndigit, "_sgets: Eigenvalues of current H matrix");
-        dvout_(&i__1, &bounds[1], &debug_1.ndigit, "_sgets: Associated Ritz estimates");
+        dvout_(&i__1, ritz, &debug_1.ndigit, "_sgets: Eigenvalues of current H matrix");
+        dvout_(&i__1, bounds, &debug_1.ndigit, "_sgets: Associated Ritz estimates");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/sgetv0.c
+++ b/src/ARPACK/arpack-ng/SRC/sgetv0.c
@@ -203,7 +203,7 @@ int sgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (*itry == 1)
         {
             ++timing_1.nopx;
-            /* TODO: subtract 1 */
+            /* TODO: ipntr index */
             ipntr[0] = 1;
             ipntr[1] = *n + 1;
             scopy_(n, resid, &c__1, workd, &c__1);
@@ -259,7 +259,7 @@ int sgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;
@@ -328,7 +328,7 @@ L30:
     {
         ++timing_1.nbx;
         scopy_(n, resid, &c__1, &workd[*n], &c__1);
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;

--- a/src/ARPACK/arpack-ng/SRC/sgetv0.c
+++ b/src/ARPACK/arpack-ng/SRC/sgetv0.c
@@ -125,7 +125,7 @@ int sgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     static bool inits = true;
 
     /* System generated locals */
-    int v_offset, i__1;
+    int i__1;
 
     /* Builtin functions */
     double sqrt(double);
@@ -140,13 +140,6 @@ int sgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     static bool first;
     static float rnorm0;
     static int msglvl;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    --ipntr;
 
     /* Function Body */
 
@@ -195,7 +188,7 @@ int sgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (! (*initv))
         {
             idist = 2;
-            slarnv_(&idist, iseed, n, &resid[1]);
+            slarnv_(&idist, iseed, n, resid);
         }
 
         /* -------------------------------------------------------- */
@@ -210,15 +203,16 @@ int sgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (*itry == 1)
         {
             ++timing_1.nopx;
-            ipntr[1] = 1;
-            ipntr[2] = *n + 1;
-            scopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+            /* TODO: subtract 1 */
+            ipntr[0] = 1;
+            ipntr[1] = *n + 1;
+            scopy_(n, resid, &c__1, workd, &c__1);
             *ido = -1;
             goto L9000;
         }
         else if (*itry > 1 && *bmat == 'G')
         {
-            scopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
+            scopy_(n, resid, &c__1, &workd[*n], &c__1);
         }
     }
 
@@ -260,19 +254,20 @@ int sgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     first = true;
     if (*itry == 1)
     {
-        scopy_(n, &workd[*n + 1], &c__1, &resid[1], &c__1);
+        scopy_(n, &workd[*n], &c__1, resid, &c__1);
     }
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
         goto L9000;
     }
     else if (*bmat == 'I')
     {
-        scopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        scopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L20:
@@ -284,12 +279,12 @@ L20:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        rnorm0 = sdot_(n, &resid[1], &c__1, &workd[1], &c__1);
+        rnorm0 = sdot_(n, resid, &c__1, workd, &c__1);
         rnorm0 = sqrt((dabs(rnorm0)));
     }
     else if (*bmat == 'I')
     {
-        rnorm0 = snrm2_(n, &resid[1], &c__1);
+        rnorm0 = snrm2_(n, resid, &c__1);
     }
     *rnorm = rnorm0;
 
@@ -318,8 +313,8 @@ L20:
 L30:
 
     i__1 = *j - 1;
-    sgemv_("T", n, &i__1, &s_one, &v[v_offset], ldv, &workd[1], &c__1, &s_zero,&workd[*n + 1], &c__1);
-    sgemv_("N", n, &i__1, &s_m1, &v[v_offset], ldv, &workd[*n + 1], &c__1, &s_one, &resid[1], &c__1);
+    sgemv_("T", n, &i__1, &s_one, v, ldv, workd, &c__1, &s_zero,&workd[*n], &c__1);
+    sgemv_("N", n, &i__1, &s_m1, v, ldv, &workd[*n], &c__1, &s_one, resid, &c__1);
 
     /* -------------------------------------------------------- */
     /* Compute the B-norm of the orthogonalized starting vector */
@@ -332,15 +327,16 @@ L30:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        scopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        scopy_(n, resid, &c__1, &workd[*n], &c__1);
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
         goto L9000;
     }
     else if (*bmat == 'I')
     {
-        scopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        scopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L40:
@@ -351,12 +347,12 @@ L40:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        *rnorm = sdot_(n, &resid[1], &c__1, &workd[1], &c__1);
+        *rnorm = sdot_(n, resid, &c__1, workd, &c__1);
         *rnorm = sqrt((dabs(*rnorm)));
     }
     else if (*bmat == 'I')
     {
-        *rnorm = snrm2_(n, &resid[1], &c__1);
+        *rnorm = snrm2_(n, resid, &c__1);
     }
 
     /* ------------------------------------ */
@@ -393,7 +389,7 @@ L40:
         /* ---------------------------------- */
 
         i__1 = *n;
-        for (jj = 1; jj <= i__1; ++jj)
+        for (jj = 0; jj < i__1; ++jj)
         {
             resid[jj] = 0.0f;
         }
@@ -411,7 +407,7 @@ L50:
 
     if (msglvl > 3)
     {
-        svout_(n, &resid[1], &debug_1.ndigit, "_getv0: initial / restarted starting vector");
+        svout_(n, resid, &debug_1.ndigit, "_getv0: initial / restarted starting vector");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/snaitr.c
+++ b/src/ARPACK/arpack-ng/SRC/snaitr.c
@@ -248,14 +248,12 @@ int snaitr_(int *ido, char *bmat, int *n, int *k,int *np, int *nb,
 
     /* Parameter adjustments */
     --workd;
-    --resid;
     v_dim = *ldv;
     v_offset = 1 + v_dim;
     v -= v_offset;
     h_dim = *ldh;
     h_offset = 1 + h_dim;
     h -= h_offset;
-    --ipntr;
 
     /* Function Body */
 
@@ -401,7 +399,7 @@ L30:
     /* RSTART = .true. flow returns here.   */
     /* ------------------------------------ */
 
-    sgetv0_(ido, bmat, &itry, &c_false, n, &j, &v[v_offset], ldv, &resid[1], rnorm, &ipntr[1], &workd[1], &ierr);
+    sgetv0_(ido, bmat, &itry, &c_false, n, &j, &v[v_offset], ldv, resid, rnorm, ipntr, &workd[1], &ierr);
     if (*ido != 99)
     {
         goto L9000;
@@ -439,7 +437,7 @@ L40:
     /* machine bound.                                          */
     /* ------------------------------------------------------- */
 
-    scopy_(n, &resid[1], &c__1, &v[j * v_dim + 1], &c__1);
+    scopy_(n, resid, &c__1, &v[j * v_dim + 1], &c__1);
     if (*rnorm >= unfl)
     {
         temp1 = 1.0f / *rnorm;
@@ -469,9 +467,9 @@ L40:
 #endif
 
     scopy_(n, &v[j * v_dim + 1], &c__1, &workd[ivj], &c__1);
-    ipntr[1] = ivj;
-    ipntr[2] = irj;
-    ipntr[3] = ipj;
+    ipntr[0] = ivj;
+    ipntr[1] = irj;
+    ipntr[2] = ipj;
     *ido = 1;
 
     /* --------------------------------- */
@@ -498,7 +496,7 @@ L50:
     /* Put another copy of OP*v_{j} into RESID. */
     /* ---------------------------------------- */
 
-    scopy_(n, &workd[irj], &c__1, &resid[1], &c__1);
+    scopy_(n, &workd[irj], &c__1, resid, &c__1);
 
     /* ------------------------------------- */
     /* STEP 4:  Finish extending the Arnoldi */
@@ -513,8 +511,8 @@ L50:
     {
         ++timing_1.nbx;
         step4 = true;
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* ----------------------------------- */
@@ -525,7 +523,7 @@ L50:
     }
     else if (*bmat == 'I')
     {
-        scopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        scopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L60:
 
@@ -548,12 +546,12 @@ L60:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        wnorm = sdot_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        wnorm = sdot_(n, resid, &c__1, &workd[ipj], &c__1);
         wnorm = sqrt((dabs(wnorm)));
     }
     else if (*bmat == 'I')
     {
-        wnorm = snrm2_(n, &resid[1], &c__1);
+        wnorm = snrm2_(n, resid, &c__1);
     }
 
     /* --------------------------------------- */
@@ -576,7 +574,7 @@ L60:
     /* RESID contains OP*v_{j}. See STEP 3. */
     /* ------------------------------------ */
 
-    sgemv_("N", n, &j, &s_m1, &v[v_offset], ldv, &h[j * h_dim + 1], &c__1,&s_one, &resid[1], &c__1);
+    sgemv_("N", n, &j, &s_m1, &v[v_offset], ldv, &h[j * h_dim + 1], &c__1,&s_one, resid, &c__1);
 
     if (j > 1)
     {
@@ -593,9 +591,9 @@ L60:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        scopy_(n, &resid[1], &c__1, &workd[irj], &c__1);
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        scopy_(n, resid, &c__1, &workd[irj], &c__1);
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* -------------------------------- */
@@ -606,7 +604,7 @@ L60:
     }
     else if (*bmat == 'I')
     {
-        scopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        scopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L70:
 
@@ -627,12 +625,12 @@ L70:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        *rnorm = sdot_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        *rnorm = sdot_(n, resid, &c__1, &workd[ipj], &c__1);
         *rnorm = sqrt((dabs(*rnorm)));
     }
     else if (*bmat == 'I')
     {
-        *rnorm = snrm2_(n, &resid[1], &c__1);
+        *rnorm = snrm2_(n, resid, &c__1);
     }
 
     /* --------------------------------------------------------- */
@@ -693,7 +691,7 @@ L80:
     /* + v(:,1:J)*WORKD(IRJ:IRJ+J-1)*e'_j.         */
     /* ------------------------------------------- */
 
-    sgemv_("N", n, &j, &s_m1, &v[v_offset], ldv, &workd[irj], &c__1, &s_one, &resid[1], &c__1);
+    sgemv_("N", n, &j, &s_m1, &v[v_offset], ldv, &workd[irj], &c__1, &s_one, resid, &c__1);
     saxpy_(&j, &s_one, &workd[irj], &c__1, &h[j * h_dim + 1], &c__1);
 
     orth2 = true;
@@ -704,9 +702,9 @@ L80:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        scopy_(n, &resid[1], &c__1, &workd[irj], &c__1);
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        scopy_(n, resid, &c__1, &workd[irj], &c__1);
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* --------------------------------- */
@@ -718,7 +716,7 @@ L80:
     }
     else if (*bmat == 'I')
     {
-        scopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        scopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L90:
 
@@ -736,12 +734,12 @@ L90:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        rnorm1 = sdot_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        rnorm1 = sdot_(n, resid, &c__1, &workd[ipj], &c__1);
         rnorm1 = sqrt((dabs(rnorm1)));
     }
     else if (*bmat == 'I')
     {
-        rnorm1 = snrm2_(n, &resid[1], &c__1);
+        rnorm1 = snrm2_(n, resid, &c__1);
     }
 
 #ifndef NO_TRACE
@@ -796,10 +794,9 @@ L90:
         /* ----------------------------------------------- */
 
         i__1 = *n;
-        for (jj = 1; jj <= i__1; ++jj)
+        for (jj = 0; jj < i__1; ++jj)
         {
             resid[jj] = 0.0f;
-
         }
         *rnorm = 0.0f;
     }
@@ -841,22 +838,21 @@ L100:
             /* Use a standard test as in the QR algorithm */
             /* REFERENCE: LAPACK subroutine slahqr        */
             /* ------------------------------------------ */
-
-            tst1 = (r__1 = h[i + i * h_dim], dabs(r__1)) + (r__2 = h[
-                        i + 1 + (i + 1) * h_dim], dabs(r__2));
+            r__1 = h[i + i * h_dim];
+            r__2 = h[i + 1 + (i + 1) * h_dim];
+            tst1 = dabs(r__1) + dabs(r__2);
             if (tst1 == 0.0f)
             {
                 i__2 = *k + *np;
                 tst1 = slanhs_("1", &i__2, &h[h_offset], ldh, &workd[*n + 1]);
             }
             /* Computing MAX */
+            r__1 = h[i + 1 + i * h_dim];
             r__2 = ulp * tst1;
-            if ((r__1 = h[i + 1 + i * h_dim], dabs(r__1)) <= dmax(r__2,
-                    smlnum))
+            if (dabs(r__1) <= dmax(r__2,smlnum))
             {
                 h[i + 1 + i * h_dim] = 0.0f;
             }
-
         }
 
 #ifndef NO_TRACE

--- a/src/ARPACK/arpack-ng/SRC/snapps.c
+++ b/src/ARPACK/arpack-ng/SRC/snapps.c
@@ -172,11 +172,6 @@ int snapps_(int *n, int *kev, int *np, float *
     static float smlnum;
 
     /* Parameter adjustments */
-    --workd;
-    --resid;
-    --workl;
-    --shifti;
-    --shiftr;
     v_dim = *ldv;
     v_offset = 1 + v_dim;
     v -= v_offset;
@@ -244,8 +239,9 @@ int snapps_(int *n, int *kev, int *np, float *
     i__1 = *np;
     for (jj = 1; jj <= i__1; ++jj)
     {
-        sigmar = shiftr[jj];
-        sigmai = shifti[jj];
+        /* TODO: fix jj - 1 */
+        sigmar = shiftr[jj - 1];
+        sigmai = shifti[jj - 1];
 
 #ifndef NO_TRACE
         if (msglvl > 2)
@@ -321,7 +317,7 @@ L20:
             if (tst1 == 0.0f)
             {
                 i__3 = kplusp - jj + 1;
-                tst1 = slanhs_("1", &i__3, &h[h_offset], ldh, &workl[1]);
+                tst1 = slanhs_("1", &i__3, &h[h_offset], ldh, workl);
             }
             /* Computing MAX */
             r__1 = h[i + 1 + i * h_dim];
@@ -515,7 +511,7 @@ L40:
                 /* ------------------------------------ */
 
                 i__3 = kplusp - i + 1;
-                slarf_("L", &nr, &i__3, u, &c__1, &tau, &h[i + i * h_dim], ldh, &workl[1]);
+                slarf_("L", &nr, &i__3, u, &c__1, &tau, &h[i + i * h_dim], ldh, workl);
 
                 /* ------------------------------------- */
                 /* Apply the reflector to the right of H */
@@ -524,13 +520,13 @@ L40:
                 /* Computing MIN */
                 i__3 = i + 3;
                 ir = min(i__3,iend);
-                slarf_("R", &ir, &nr, u, &c__1, &tau, &h[i * h_dim + 1], ldh, &workl[1]);
+                slarf_("R", &ir, &nr, u, &c__1, &tau, &h[i * h_dim + 1], ldh, workl);
 
                 /* --------------------------------------------------- */
                 /* Accumulate the reflector in the matrix Q;  Q <- Q*G */
                 /* --------------------------------------------------- */
 
-                slarf_("R", &kplusp, &nr, u, &c__1, &tau, &q[i * q_dim + 1], ldq, &workl[1]);
+                slarf_("R", &kplusp, &nr, u, &c__1, &tau, &q[i * q_dim + 1], ldq, workl);
 
                 /* -------------------------- */
                 /* Prepare for next reflector */
@@ -611,7 +607,7 @@ L110:
         tst1 = dabs(r__1) + dabs(r__2);
         if (tst1 == 0.0f)
         {
-            tst1 = slanhs_("1", kev, &h[h_offset], ldh, &workl[1]);
+            tst1 = slanhs_("1", kev, &h[h_offset], ldh, workl);
         }
         /* Computing MAX */
         r__1 = ulp * tst1;
@@ -631,7 +627,7 @@ L110:
 
     if (h[*kev + 1 + *kev * h_dim] > 0.0f)
     {
-        sgemv_("N", n, &kplusp, &s_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &s_zero, &workd[*n + 1], &c__1);
+        sgemv_("N", n, &kplusp, &s_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &s_zero, &workd[*n], &c__1);
     }
 
     /* -------------------------------------------------------- */
@@ -643,8 +639,8 @@ L110:
     for (i = 1; i <= i__1; ++i)
     {
         i__2 = kplusp - i + 1;
-        sgemv_("N", n, &i__2, &s_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &s_zero, &workd[1], &c__1);
-        scopy_(n, &workd[1], &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
+        sgemv_("N", n, &i__2, &s_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &s_zero, workd, &c__1);
+        scopy_(n, workd, &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------------------- */
@@ -659,7 +655,7 @@ L110:
 
     if (h[*kev + 1 + *kev * h_dim] > 0.0f)
     {
-        scopy_(n, &workd[*n + 1], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
+        scopy_(n, &workd[*n], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------- */
@@ -670,10 +666,10 @@ L110:
     /*    betak = e_{kev+1}'*H*e_{kev}     */
     /* ----------------------------------- */
 
-    sscal_(n, &q[kplusp + *kev * q_dim], &resid[1], &c__1);
+    sscal_(n, &q[kplusp + *kev * q_dim], resid, &c__1);
     if (h[*kev + 1 + *kev * h_dim] > 0.0f)
     {
-        saxpy_(n, &h[*kev + 1 + *kev * h_dim], &v[(*kev + 1) * v_dim + 1],&c__1, &resid[1], &c__1);
+        saxpy_(n, &h[*kev + 1 + *kev * h_dim], &v[(*kev + 1) * v_dim + 1],&c__1, resid, &c__1);
     }
 
 #ifndef NO_TRACE

--- a/src/ARPACK/arpack-ng/SRC/snaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/snaup2.c
@@ -809,7 +809,7 @@ L50:
     {
         ++timing_1.nbx;
         scopy_(n, resid, &c__1, &workd[*n], &c__1);
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;

--- a/src/ARPACK/arpack-ng/SRC/snaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/snaup2.c
@@ -180,7 +180,7 @@ int snaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
             int *info)
 {
     /* System generated locals */
-    int h_dim, h_offset, q_offset, v_offset, i__1, i__2;
+    int i__1, i__2;
     float r__1, r__2;
 
     /* Builtin functions */
@@ -207,22 +207,6 @@ int snaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     static int kplusp, msglvl;
     int nptemp;
     static int numcnv;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    --workl;
-    --bounds;
-    --ritzi;
-    --ritzr;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    h_dim = *ldh;
-    h_offset = 1 + h_dim;
-    h -= h_offset;
-    q_offset = 1 + *ldq;
-    q -= q_offset;
-    --ipntr;
 
     /* Function Body */
     if (*ido == 0)
@@ -290,7 +274,7 @@ int snaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
 
     if (getv0)
     {
-        sgetv0_(ido, bmat, &c__1, &initv, n, &c__1, &v[v_offset], ldv, &resid[1], &rnorm, &ipntr[1], &workd[1], info);
+        sgetv0_(ido, bmat, &c__1, &initv, n, &c__1, v, ldv, resid, &rnorm, ipntr, workd, info);
 
         if (*ido != 99)
         {
@@ -343,7 +327,7 @@ int snaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     /* Compute the first NEV steps of the Arnoldi factorization */
     /* -------------------------------------------------------- */
 
-    snaitr_(ido, bmat, n, &c__0, nev, mode, &resid[1], &rnorm, &v[v_offset], ldv, &h[h_offset], ldh, &ipntr[1], &workd[1], info);
+    snaitr_(ido, bmat, n, &c__0, nev, mode, resid, &rnorm, v, ldv, h, ldh, ipntr, workd, info);
 
     /* ------------------------------------------------- */
     /* ido .ne. 99 implies use of reverse communication  */
@@ -406,7 +390,7 @@ L1000:
 L20:
     update = true;
 
-    snaitr_(ido, bmat, n, nev, np, mode, &resid[1], &rnorm, &v[v_offset], ldv,&h[h_offset], ldh, &ipntr[1], &workd[1], info);
+    snaitr_(ido, bmat, n, nev, np, mode, resid, &rnorm, v, ldv,h, ldh, ipntr, workd, info);
 
     /* ------------------------------------------------- */
     /* ido .ne. 99 implies use of reverse communication  */
@@ -439,7 +423,7 @@ L20:
     /* of the current upper Hessenberg matrix.                */
     /* ------------------------------------------------------ */
 
-    sneigh_(&rnorm, &kplusp, &h[h_offset], ldh, &ritzr[1], &ritzi[1], &bounds[1], &q[q_offset], ldq, &workl[1], &ierr);
+    sneigh_(&rnorm, &kplusp, h, ldh, ritzr, ritzi, bounds, q, ldq, workl, &ierr);
 
     if (ierr != 0)
     {
@@ -454,9 +438,9 @@ L20:
 
     /* Computing 2nd power */
     i__1 = kplusp * kplusp;
-    scopy_(&kplusp, &ritzr[1], &c__1, &workl[i__1 + 1], &c__1);
-    scopy_(&kplusp, &ritzi[1], &c__1, &workl[i__1 + kplusp + 1], &c__1);
-    scopy_(&kplusp, &bounds[1], &c__1, &workl[i__1 + (kplusp << 1) + 1], &c__1);
+    scopy_(&kplusp, ritzr, &c__1, &workl[i__1], &c__1);
+    scopy_(&kplusp, ritzi, &c__1, &workl[i__1 + kplusp], &c__1);
+    scopy_(&kplusp, bounds, &c__1, &workl[i__1 + (kplusp << 1)], &c__1);
 
     /* ------------------------------------------------- */
     /* Select the wanted Ritz values and their bounds    */
@@ -474,7 +458,7 @@ L20:
     *nev = nev0;
     *np = np0;
     numcnv = *nev;
-    sngets_(ishift, which, nev, np, &ritzr[1], &ritzi[1], &bounds[1], &workl[1], &workl[*np + 1]);
+    sngets_(ishift, which, nev, np, ritzr, ritzi, bounds, workl, &workl[*np]);
     if (*nev == nev0 + 1)
     {
         numcnv = nev0 + 1;
@@ -484,8 +468,8 @@ L20:
     /* Convergence test. */
     /* ----------------- */
 
-    scopy_(nev, &bounds[*np + 1], &c__1, &workl[(*np << 1) + 1], &c__1);
-    snconv_(nev, &ritzr[*np + 1], &ritzi[*np + 1], &workl[(*np << 1) + 1], tol, &nconv);
+    scopy_(nev, &bounds[*np], &c__1, &workl[*np << 1], &c__1);
+    snconv_(nev, &ritzr[*np], &ritzi[*np], &workl[*np << 1], tol, &nconv);
 
 #ifndef NO_TRACE
     if (msglvl > 2)
@@ -495,9 +479,9 @@ L20:
         kp[2] = numcnv;
         kp[3] = nconv;
         ivout_(&c__4, kp, &debug_1.ndigit, "_naup2: NEV, NP, NUMCNV, NCONV are");
-        svout_(&kplusp, &ritzr[1], &debug_1.ndigit, "_naup2: Real part of the eigenvalues of H");
-        svout_(&kplusp, &ritzi[1], &debug_1.ndigit, "_naup2: Imaginary part of the eigenvalues of H");
-        svout_(&kplusp, &bounds[1], &debug_1.ndigit, "_naup2: Ritz estimates of the current NCV Ritz values");
+        svout_(&kplusp, ritzr, &debug_1.ndigit, "_naup2: Real part of the eigenvalues of H");
+        svout_(&kplusp, ritzi, &debug_1.ndigit, "_naup2: Imaginary part of the eigenvalues of H");
+        svout_(&kplusp, bounds, &debug_1.ndigit, "_naup2: Ritz estimates of the current NCV Ritz values");
     }
 #endif
 
@@ -512,7 +496,7 @@ L20:
     /* ------------------------------------------------------- */
 
     nptemp = *np;
-    for (j = 1; j <= nptemp; ++j)
+    for (j = 0; j < nptemp; ++j)
     {
         if (bounds[j] == 0.0f)
         {
@@ -529,9 +513,9 @@ L20:
         {
             /* Computing 2nd power */
             i__1 = kplusp * kplusp;
-            svout_(&kplusp, &workl[i__1 + 1], &debug_1.ndigit, "_naup2: Real part of the eig computed by _neigh:");
-            svout_(&kplusp, &workl[i__1 + kplusp + 1],&debug_1.ndigit, "_naup2: Imag part of the eig computed by _neigh:");
-            svout_(&kplusp, &workl[i__1 + (kplusp << 1) + 1], &debug_1.ndigit, "_naup2: Ritz eistmates computed by _neigh:");
+            svout_(&kplusp, &workl[i__1], &debug_1.ndigit, "_naup2: Real part of the eig computed by _neigh:");
+            svout_(&kplusp, &workl[i__1 + kplusp],&debug_1.ndigit, "_naup2: Imag part of the eig computed by _neigh:");
+            svout_(&kplusp, &workl[i__1 + (kplusp << 1)], &debug_1.ndigit, "_naup2: Ritz eistmates computed by _neigh:");
         }
 #endif
 
@@ -546,7 +530,7 @@ L20:
         /*  Use h( 3,1 ) as storage to communicate  */
         /*  rnorm to _neupd if needed               */
         /* ---------------------------------------- */
-        h[h_dim + 3] = rnorm;
+        h[2] = rnorm;
 
         /* -------------------------------------------- */
         /* To be consistent with sngets, we first do a  */
@@ -582,7 +566,7 @@ L20:
             strcpy(wprime, "LM");
         }
 
-        ssortc_(wprime, &c_true, &kplusp, &ritzr[1], &ritzi[1], &bounds[1]);
+        ssortc_(wprime, &c_true, &kplusp, ritzr, ritzi, bounds);
 
         /* -------------------------------------------- */
         /* Now sort Ritz values so that converged Ritz  */
@@ -616,14 +600,14 @@ L20:
             strcpy(wprime, "LI");
         }
 
-        ssortc_(wprime, &c_true, &kplusp, &ritzr[1], &ritzi[1], &bounds[1]);
+        ssortc_(wprime, &c_true, &kplusp, ritzr, ritzi, bounds);
 
         /* ------------------------------------------------ */
         /* Scale the Ritz estimate of each Ritz value       */
         /* by 1 / max(eps23,magnitude of the Ritz value).   */
         /* ------------------------------------------------ */
 
-        for (j = 1; j <= numcnv; ++j)
+        for (j = 0; j < numcnv; ++j)
         {
             /* Computing MAX */
             r__1 = eps23, r__2 = slapy2_(&ritzr[j], &ritzi[j]);
@@ -639,14 +623,14 @@ L20:
         /* -------------------------------------------------- */
 
         strcpy(wprime, "LR");
-        ssortc_(wprime, &c_true, &numcnv, &bounds[1], &ritzr[1], &ritzi[1]);
+        ssortc_(wprime, &c_true, &numcnv, bounds, ritzr, ritzi);
 
         /* -------------------------------------------- */
         /* Scale the Ritz estimate back to its original */
         /* value.                                       */
         /* -------------------------------------------- */
 
-        for (j = 1; j <= numcnv; ++j)
+        for (j = 0; j < numcnv; ++j)
         {
             /* Computing MAX */
             r__1 = eps23, r__2 = slapy2_(&ritzr[j], &ritzi[j]);
@@ -660,14 +644,14 @@ L20:
         /* ritzr, ritzi and bound.                        */
         /* ---------------------------------------------- */
 
-        ssortc_(which, &c_true, &nconv, &ritzr[1], &ritzi[1], &bounds[1]);
+        ssortc_(which, &c_true, &nconv, ritzr, ritzi, bounds);
 
 #ifndef NO_TRACE
         if (msglvl > 1)
         {
-            svout_(&kplusp, &ritzr[1], &debug_1.ndigit, "_naup2: Sorted float part of the eigenvalues");
-            svout_(&kplusp, &ritzi[1], &debug_1.ndigit, "_naup2: Sorted imaginary part of the eigenvalues");
-            svout_(&kplusp, &bounds[1], &debug_1.ndigit, "_naup2: Sorted ritz estimates.");
+            svout_(&kplusp, ritzr, &debug_1.ndigit, "_naup2: Sorted float part of the eigenvalues");
+            svout_(&kplusp, ritzi, &debug_1.ndigit, "_naup2: Sorted imaginary part of the eigenvalues");
+            svout_(&kplusp, bounds, &debug_1.ndigit, "_naup2: Sorted ritz estimates.");
         }
 #endif
 
@@ -733,7 +717,7 @@ L20:
 
         if (nevbef < *nev)
         {
-            sngets_(ishift, which, nev, np, &ritzr[1], &ritzi[1], &bounds[1], &workl[1], &workl[*np + 1]);
+            sngets_(ishift, which, nev, np, ritzr, ritzi, bounds, workl, &workl[*np]);
         }
     }
 
@@ -746,9 +730,9 @@ L20:
             kp[0] = *nev;
             kp[1] = *np;
             ivout_(&c__2, kp, &debug_1.ndigit, "_naup2: NEV and NP are");
-            svout_(nev, &ritzr[*np + 1], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values -- float part");
-            svout_(nev, &ritzi[*np + 1], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values -- imag part");
-            svout_(nev, &bounds[*np + 1], &debug_1.ndigit, "_naup2: Ritz estimates of the \"wanted\" values ");
+            svout_(nev, &ritzr[*np], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values -- float part");
+            svout_(nev, &ritzi[*np], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values -- imag part");
+            svout_(nev, &bounds[*np], &debug_1.ndigit, "_naup2: Ritz estimates of the \"wanted\" values ");
         }
     }
 #endif
@@ -784,19 +768,19 @@ L50:
         /* for non-exact shift case.        */
         /* -------------------------------- */
 
-        scopy_(np, &workl[1], &c__1, &ritzr[1], &c__1);
-        scopy_(np, &workl[*np + 1], &c__1, &ritzi[1], &c__1);
+        scopy_(np, workl, &c__1, ritzr, &c__1);
+        scopy_(np, &workl[*np], &c__1, ritzi, &c__1);
     }
 
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
         ivout_(&c__1, np, &debug_1.ndigit, "_naup2: The number of shifts to apply ");
-        svout_(np, &ritzr[1], &debug_1.ndigit, "_naup2: Real part of the shifts");
-        svout_(np, &ritzi[1], &debug_1.ndigit, "_naup2: Imaginary part of the shifts");
+        svout_(np, ritzr, &debug_1.ndigit, "_naup2: Real part of the shifts");
+        svout_(np, ritzi, &debug_1.ndigit, "_naup2: Imaginary part of the shifts");
         if (*ishift == 1)
         {
-            svout_(np, &bounds[1], &debug_1.ndigit, "_naup2: Ritz estimates of the shifts");
+            svout_(np, bounds, &debug_1.ndigit, "_naup2: Ritz estimates of the shifts");
         }
     }
 #endif
@@ -808,7 +792,7 @@ L50:
     /* The first 2*N locations of WORKD are used as workspace. */
     /* ------------------------------------------------------- */
 
-    snapps_(n, nev, np, &ritzr[1], &ritzi[1], &v[v_offset], ldv, &h[h_offset], ldh, &resid[1], &q[q_offset], ldq, &workl[1], &workd[1]);
+    snapps_(n, nev, np, ritzr, ritzi, v, ldv, h, ldh, resid, q, ldq, workl, workd);
 
     /* ------------------------------------------- */
     /* Compute the B-norm of the updated residual. */
@@ -824,9 +808,10 @@ L50:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        scopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        scopy_(n, resid, &c__1, &workd[*n], &c__1);
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
 
         /* -------------------------------- */
@@ -837,7 +822,7 @@ L50:
     }
     else if (*bmat == 'I')
     {
-        scopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        scopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L100:
@@ -853,12 +838,12 @@ L100:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        rnorm = sdot_(n, &resid[1], &c__1, &workd[1], &c__1);
+        rnorm = sdot_(n, resid, &c__1, workd, &c__1);
         rnorm = sqrt((dabs(rnorm)));
     }
     else if (*bmat == 'I')
     {
-        rnorm = snrm2_(n, &resid[1], &c__1);
+        rnorm = snrm2_(n, resid, &c__1);
     }
     cnorm = false;
 
@@ -866,7 +851,7 @@ L100:
     if (msglvl > 2)
     {
         svout_(&c__1, &rnorm, &debug_1.ndigit, "_naup2: B-norm of residual for compressed factorization");
-        smout_(nev, nev, &h[h_offset], ldh, &debug_1.ndigit, "_naup2: Compressed upper Hessenberg matrix H");
+        smout_(nev, nev, h, ldh, &debug_1.ndigit, "_naup2: Compressed upper Hessenberg matrix H");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/snaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/snaupd.c
@@ -413,7 +413,7 @@ int snaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 {
 
     /* System generated locals */
-    int v_offset, i__1, i__2;
+    int i__1, i__2;
 
     /* Local variables */
     int j, ierr;
@@ -424,21 +424,11 @@ int snaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 
     int ldh = *ncv;
     int ldq = *ncv;
-    int ih = 1;
-    int ritzr = ih + ldh * *ncv;
+    int ritzr =  ldh * *ncv;
     int ritzi = ritzr + *ncv;
     int bounds = ritzi + *ncv;
     int iq = bounds + *ncv;
     int iw = iq + ldq * *ncv;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    --iparam;
-    --ipntr;
-    --workl;
 
     /* Function Body */
     if (*ido == 0)
@@ -458,16 +448,16 @@ int snaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
         /* -------------- */
 
         ierr = 0;
-        ishift = iparam[1];
-        /*         levec  = iparam(2) */
-        mxiter = iparam[3];
-        /*         nb     = iparam(4) */
+        ishift = iparam[0];
+        /* levec  = iparam(2) */
+        mxiter = iparam[2];
+        /* nb     = iparam(4) */
 
         /* ------------------------------------------ */
         /* Revision 2 performs only implicit restart. */
         /* ------------------------------------------ */
 
-        mode = iparam[7];
+        mode = iparam[6];
 
         if (*n <= 0)
         {
@@ -554,7 +544,7 @@ int snaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
         /* Computing 2nd power */
         i__2 = *ncv;
         i__1 = i__2 * i__2 * 3 + *ncv * 6;
-        for (j = 1; j <= i__1; ++j)
+        for (j = 0; j < i__1; ++j)
         {
             workl[j] = 0.0f;
         }
@@ -579,19 +569,20 @@ int snaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 
         /* Computing 2nd power */
         i__1 = *ncv;
-        ipntr[4] = iw + i__1 * i__1 + i__1 * 3;
-        ipntr[5] = ih;
-        ipntr[6] = ritzr;
-        ipntr[7] = ritzi;
-        ipntr[8] = bounds;
-        ipntr[14] = iw;
+        /* TODO: subtract 1 !!! */
+        ipntr[3] = 1 + iw + i__1 * i__1 + i__1 * 3;
+        ipntr[4] = 1;
+        ipntr[5] = 1 + ritzr;
+        ipntr[6] = 1 + ritzi;
+        ipntr[7] = 1 + bounds;
+        ipntr[13] = 1 + iw;
     }
 
     /* ----------------------------------------------------- */
     /* Carry out the Implicitly restarted Arnoldi Iteration. */
     /* ----------------------------------------------------- */
 
-    snaup2_(ido, bmat, n, which, &nev0, &np, tol, &resid[1], &mode, &iupd, &ishift, &mxiter, &v[v_offset], ldv, &workl[ih], &ldh, &workl[ritzr], &workl[ritzi], &workl[bounds], &workl[iq], &ldq, &workl[iw], &ipntr[1], &workd[1], info);
+    snaup2_(ido, bmat, n, which, &nev0, &np, tol, resid, &mode, &iupd, &ishift, &mxiter, v, ldv, workl, &ldh, &workl[ritzr], &workl[ritzi], &workl[bounds], &workl[iq], &ldq, &workl[iw], ipntr, workd, info);
 
     /* ------------------------------------------------ */
     /* ido .ne. 99 implies use of reverse communication */
@@ -600,18 +591,18 @@ int snaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 
     if (*ido == 3)
     {
-        iparam[8] = np;
+        iparam[7] = np;
     }
     if (*ido != 99)
     {
         goto L9000;
     }
 
-    iparam[3] = mxiter;
-    iparam[5] = np;
-    iparam[9] = timing_1.nopx;
-    iparam[10] = timing_1.nbx;
-    iparam[11] = timing_1.nrorth;
+    iparam[2] = mxiter;
+    iparam[4] = np;
+    iparam[8] = timing_1.nopx;
+    iparam[9] = timing_1.nbx;
+    iparam[10] = timing_1.nrorth;
 
     /* ---------------------------------- */
     /* Exit if there was an informational */

--- a/src/ARPACK/arpack-ng/SRC/snaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/snaupd.c
@@ -566,10 +566,9 @@ int snaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
         /* matrix.                                                     */
         /* ----------------------------------------------------------- */
 
-
         /* Computing 2nd power */
         i__1 = *ncv;
-        /* TODO: subtract 1 !!! */
+        /* TODO: ipntr index */
         ipntr[3] = 1 + iw + i__1 * i__1 + i__1 * 3;
         ipntr[4] = 1;
         ipntr[5] = 1 + ritzr;

--- a/src/ARPACK/arpack-ng/SRC/sneigh.c
+++ b/src/ARPACK/arpack-ng/SRC/sneigh.c
@@ -101,7 +101,7 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
             workl, int *ierr)
 {
     /* System generated locals */
-    int h_offset, q_dim, q_offset, i__1;
+    int q_dim, i__1;
     float r__1, r__2;
 
     /* Local variables */
@@ -112,22 +112,12 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
     bool select[1];
     int msglvl;
 
-
     /* ----------------------------- */
     /* Initialize timing statistics  */
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --workl;
-    --bounds;
-    --ritzi;
-    --ritzr;
-    h_offset = 1 + *ldh;
-    h -= h_offset;
     q_dim = *ldq;
-    q_offset = 1 + q_dim;
-    q -= q_offset;
 
     /* Function Body */
 #ifndef NO_TIMER
@@ -139,7 +129,7 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
-        smout_(n, n, &h[h_offset], ldh, &debug_1.ndigit, "_neigh: Entering upper Hessenberg matrix H ");
+        smout_(n, n, h, ldh, &debug_1.ndigit, "_neigh: Entering upper Hessenberg matrix H ");
     }
 #endif
 
@@ -151,14 +141,14 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
     /* and the last components of the Schur vectors in BOUNDS.   */
     /* --------------------------------------------------------- */
 
-    slacpy_("A", n, n, &h[h_offset], ldh, &workl[1], n);
+    slacpy_("A", n, n, h, ldh, workl, n);
     i__1 = *n - 1;
-    for (j = 1; j <= i__1; ++j)
+    for (j = 0; j < i__1; ++j)
     {
         bounds[j] = 0.0f;
     }
-    bounds[*n] = 1.0f;
-    slahqr_(&c_true, &c_true, n, &c__1, n, &workl[1], n, &ritzr[1], &ritzi[1],&c__1, &c__1, &bounds[1], &c__1, ierr);
+    bounds[*n - 1] = 1.0f;
+    slahqr_(&c_true, &c_true, n, &c__1, n, workl, n, ritzr, ritzi,&c__1, &c__1, bounds, &c__1, ierr);
     if (*ierr != 0)
     {
         goto L9000;
@@ -167,7 +157,7 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
 #ifndef NO_TRACE
     if (msglvl > 1)
     {
-        svout_(n, &bounds[1], &debug_1.ndigit, "_neigh: last row of the Schur matrix for H");
+        svout_(n, bounds, &debug_1.ndigit, "_neigh: last row of the Schur matrix for H");
     }
 #endif
 
@@ -181,7 +171,7 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
     /* columns of Q.                                             */
     /* --------------------------------------------------------- */
 
-    strevc_("R", "A", select, n, &workl[1], n, vl, n, &q[q_offset], ldq, n, n,&workl[*n * *n + 1], ierr);
+    strevc_("R", "A", select, n, workl, n, vl, n, q, ldq, n, n,&workl[*n * *n], ierr);
 
     if (*ierr != 0)
     {
@@ -199,7 +189,7 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
 
     iconj = 0;
     i__1 = *n;
-    for (i = 1; i <= i__1; ++i)
+    for (i = 0; i < i__1; ++i)
     {
         if ((r__1 = ritzi[i], dabs(r__1)) <= 0.0f)
         {
@@ -207,9 +197,9 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
             /* Real eigenvalue case */
             /* -------------------- */
 
-            temp = snrm2_(n, &q[i * q_dim + 1], &c__1);
+            temp = snrm2_(n, &q[i * q_dim], &c__1);
             r__1 = 1.0f / temp;
-            sscal_(n, &r__1, &q[i * q_dim + 1], &c__1);
+            sscal_(n, &r__1, &q[i * q_dim], &c__1);
         }
         else
         {
@@ -223,13 +213,13 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
 
             if (iconj == 0)
             {
-                r__1 = snrm2_(n, &q[i * q_dim + 1], &c__1);
-                r__2 = snrm2_(n, &q[(i + 1) * q_dim + 1], &c__1);
+                r__1 = snrm2_(n, &q[i * q_dim], &c__1);
+                r__2 = snrm2_(n, &q[(i + 1) * q_dim], &c__1);
                 temp = slapy2_(&r__1, &r__2);
                 r__1 = 1.0f / temp;
-                sscal_(n, &r__1, &q[i * q_dim + 1], &c__1);
+                sscal_(n, &r__1, &q[i * q_dim], &c__1);
                 r__1 = 1.0f / temp;
-                sscal_(n, &r__1, &q[(i + 1) * q_dim + 1], &c__1);
+                sscal_(n, &r__1, &q[(i + 1) * q_dim], &c__1);
                 iconj = 1;
             }
             else
@@ -239,12 +229,12 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
         }
     }
 
-    sgemv_("T", n, n, &s_one, &q[q_offset], ldq, &bounds[1], &c__1, &s_zero, &workl[1], &c__1);
+    sgemv_("T", n, n, &s_one, q, ldq, bounds, &c__1, &s_zero, workl, &c__1);
 
 #ifndef NO_TRACE
     if (msglvl > 1)
     {
-        svout_(n, &workl[1], &debug_1.ndigit, "_neigh: Last row of the eigenvector matrix for H");
+        svout_(n, workl, &debug_1.ndigit, "_neigh: Last row of the eigenvector matrix for H");
     }
 #endif
 
@@ -254,7 +244,7 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
 
     iconj = 0;
     i__1 = *n;
-    for (i = 1; i <= i__1; ++i)
+    for (i = 0; i < i__1; ++i)
     {
         if ((r__1 = ritzi[i], dabs(r__1)) <= 0.0f)
         {
@@ -290,9 +280,9 @@ int sneigh_(float *rnorm, int *n, float *h, int *ldh,
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
-        svout_(n, &ritzr[1], &debug_1.ndigit, "_neigh: Real part of the eigenvalues of H");
-        svout_(n, &ritzi[1], &debug_1.ndigit, "_neigh: Imaginary part of the eigenvalues of H");
-        svout_(n, &bounds[1], &debug_1.ndigit, "_neigh: Ritz estimates for the eigenvalues of H");
+        svout_(n, ritzr, &debug_1.ndigit, "_neigh: Real part of the eigenvalues of H");
+        svout_(n, ritzi, &debug_1.ndigit, "_neigh: Imaginary part of the eigenvalues of H");
+        svout_(n, bounds, &debug_1.ndigit, "_neigh: Ritz estimates for the eigenvalues of H");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/sneupd.c
+++ b/src/ARPACK/arpack-ng/SRC/sneupd.c
@@ -312,7 +312,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
             int *info)
 {
     /* System generated locals */
-    int v_offset, z_offset, i__1;
+    int i__1;
     float r__1, r__2;
 
     /* Builtin functions */
@@ -341,10 +341,6 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
 
 
     /* Parameter adjustments */
-    z_offset = 1 + *ldz;
-    z -= z_offset;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
     --select;
     --workl;
 
@@ -713,8 +709,8 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
         /* matrix of order NCONV in workl(iuptri)                  */
         /* ------------------------------------------------------- */
 
-        sorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &v[v_offset], ldv, &workd[*n], &ierr);
-        slacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
+        sorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, v, ldv, &workd[*n], &ierr);
+        slacpy_("A", n, &nconv, v, ldv, z, ldz);
 
         for (j = 1; j <= nconv; ++j)
         {
@@ -871,8 +867,8 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
             /* in workl(iheigr) and workl(iheigi).          */
             /* -------------------------------------------- */
 
-            sorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &z[z_offset], ldz, &workd[*n], &ierr);
-            strmm_("R", "U", "N", "N", n, &nconv, &s_one, &workl[invsub], &ldq, &z[z_offset], ldz);
+            sorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, z, ldz, &workd[*n], &ierr);
+            strmm_("R", "U", "N", "N", n, &nconv, &s_one, &workl[invsub], &ldq, z, ldz);
         }
     }
     else
@@ -1033,7 +1029,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
         /* purify all the Ritz vectors together. */
         /* ------------------------------------- */
 
-        sger_(n, &nconv, &s_one, resid, &c__1, workev, &c__1, &z[z_offset], ldz);
+        sger_(n, &nconv, &s_one, resid, &c__1, workev, &c__1, z, ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/sneupd.c
+++ b/src/ARPACK/arpack-ng/SRC/sneupd.c
@@ -331,7 +331,8 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
     int ihbds, iconj;
     float conds;
     bool reord;
-    int nconv, iwork[1];
+    int nconv;
+    int iwork[1];
     float rnorm;
     int ritzi;
     int ritzr;
@@ -342,22 +343,15 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
     /* Parameter adjustments */
     z_offset = 1 + *ldz;
     z -= z_offset;
-    --workd;
-    --resid;
-    --di;
-    --dr;
-    --workev;
-    --select;
     v_offset = 1 + *ldv;
     v -= v_offset;
-    --iparam;
-    --ipntr;
+    --select;
     --workl;
 
     /* Function Body */
     msglvl = debug_1.mneupd;
-    mode = iparam[7];
-    nconv = iparam[5];
+    mode = iparam[6];
+    nconv = iparam[4];
     *info = 0;
 
     /* ------------------------------- */
@@ -479,10 +473,10 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
     /* GRAND total of NCV * ( 3 * NCV + 6 ) locations.           */
     /* --------------------------------------------------------- */
 
-    ih = ipntr[5];
-    ritzr = ipntr[6];
-    ritzi = ipntr[7];
-    bounds = ipntr[8];
+    ih = ipntr[4];
+    ritzr = ipntr[5];
+    ritzi = ipntr[6];
+    bounds = ipntr[7];
     ldh = *ncv;
     ldq = *ncv;
     iheigr = bounds + ldh;
@@ -490,11 +484,11 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
     ihbds = iheigi + ldh;
     iuptri = ihbds + ldh;
     invsub = iuptri + ldh * *ncv;
-    ipntr[9] = iheigr;
-    ipntr[10] = iheigi;
-    ipntr[11] = ihbds;
-    ipntr[12] = iuptri;
-    ipntr[13] = invsub;
+    ipntr[8] = iheigr;
+    ipntr[9] = iheigi;
+    ipntr[10] = ihbds;
+    ipntr[11] = iuptri;
+    ipntr[12] = invsub;
     wrr = 1;
     wri = *ncv + 1;
     iwev = wri + *ncv;
@@ -511,7 +505,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
     /*     _naup2.                             */
     /* --------------------------------------- */
 
-    irr = ipntr[14] + *ncv * *ncv;
+    irr = ipntr[13] + *ncv * *ncv;
     iri = irr + *ncv;
     ibd = iri + *ncv;
 
@@ -695,8 +689,8 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
 
         if (strcmp(type, "REGULR") == 0)
         {
-            scopy_(&nconv, &workl[iheigr], &c__1, &dr[1], &c__1);
-            scopy_(&nconv, &workl[iheigi], &c__1, &di[1], &c__1);
+            scopy_(&nconv, &workl[iheigr], &c__1, dr, &c__1);
+            scopy_(&nconv, &workl[iheigi], &c__1, di, &c__1);
         }
 
         /* -------------------------------------------------------- */
@@ -705,7 +699,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
         /* columns of workl(invsub,ldq).                            */
         /* -------------------------------------------------------- */
 
-        sgeqr2_(ncv, &nconv, &workl[invsub], &ldq, &workev[1], &workev[*ncv + 1], &ierr);
+        sgeqr2_(ncv, &nconv, &workl[invsub], &ldq, workev, &workev[*ncv], &ierr);
 
         /* ------------------------------------------------------- */
         /* * Postmultiply V by Q using sorm2r.                     */
@@ -719,7 +713,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
         /* matrix of order NCONV in workl(iuptri)                  */
         /* ------------------------------------------------------- */
 
-        sorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, &workev[1], &v[v_offset], ldv, &workd[*n + 1], &ierr);
+        sorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &v[v_offset], ldv, &workd[*n], &ierr);
         slacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
 
         for (j = 1; j <= nconv; ++j)
@@ -760,7 +754,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
                 }
             }
 
-            strevc_("R", "S", &select[1], ncv, &workl[iuptri], &ldq, vl, &c__1, &workl[invsub], &ldq, ncv, &outncv, &workev[1],&ierr);
+            strevc_("R", "S", &select[1], ncv, &workl[iuptri], &ldq, vl, &c__1, &workl[invsub], &ldq, ncv, &outncv, workev,&ierr);
 
             if (ierr != 0)
             {
@@ -779,7 +773,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
             iconj = 0;
             for (j = 1; j <= nconv; ++j)
             {
-                if (workl[iheigi + j - 1] == 0.0f)
+                if (workl[iheigi + j] == 0.0f)
                 {
                     /* -------------------- */
                     /* real eigenvalue case */
@@ -817,12 +811,12 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
                 }
             }
 
-            sgemv_("T", ncv, &nconv, &s_one, &workl[invsub], &ldq, &workl[ihbds], &c__1, &s_zero, &workev[1], &c__1);
+            sgemv_("T", ncv, &nconv, &s_one, &workl[invsub], &ldq, &workl[ihbds], &c__1, &s_zero, workev, &c__1);
 
             iconj = 0;
-            for (j = 1; j <= nconv; ++j)
+            for (j = 0; j < nconv; ++j)
             {
-                if (workl[iheigi + j - 1] != 0.0f)
+                if (workl[iheigi + j] != 0.0f)
                 {
                     /* ----------------------------------------- */
                     /* Complex conjugate pair case. Note that    */
@@ -859,7 +853,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
             /* Copy Ritz estimates into workl(ihbds) */
             /* ------------------------------------- */
 
-            scopy_(&nconv, &workev[1], &c__1, &workl[ihbds], &c__1);
+            scopy_(&nconv, workev, &c__1, &workl[ihbds], &c__1);
 
             /* ------------------------------------------------------- */
             /* Compute the QR factorization of the eigenvector matrix  */
@@ -867,7 +861,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
             /* columns of workl(invsub,ldq).                           */
             /* ------------------------------------------------------- */
 
-            sgeqr2_(ncv, &nconv, &workl[invsub], &ldq, &workev[1], &workev[*ncv + 1], &ierr);
+            sgeqr2_(ncv, &nconv, &workl[invsub], &ldq, workev, &workev[*ncv], &ierr);
 
             /* -------------------------------------------- */
             /* * Postmultiply Z by Q.                       */
@@ -877,7 +871,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
             /* in workl(iheigr) and workl(iheigi).          */
             /* -------------------------------------------- */
 
-            sorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, &workev[1], &z[z_offset], ldz, &workd[*n + 1], &ierr);
+            sorm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &z[z_offset], ldz, &workd[*n], &ierr);
             strmm_("R", "U", "N", "N", n, &nconv, &s_one, &workl[invsub], &ldq, &z[z_offset], ldz);
         }
     }
@@ -888,8 +882,8 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
         /* Place the Ritz values computed SNAUPD into DR and DI */
         /* ---------------------------------------------------- */
 
-        scopy_(&nconv, &workl[ritzr], &c__1, &dr[1], &c__1);
-        scopy_(&nconv, &workl[ritzi], &c__1, &di[1], &c__1);
+        scopy_(&nconv, &workl[ritzr], &c__1, dr, &c__1);
+        scopy_(&nconv, &workl[ritzi], &c__1, di, &c__1);
         scopy_(&nconv, &workl[ritzr], &c__1, &workl[iheigr], &c__1);
         scopy_(&nconv, &workl[ritzi], &c__1, &workl[iheigi], &c__1);
         scopy_(&nconv, &workl[bounds], &c__1, &workl[ihbds], &c__1);
@@ -924,23 +918,24 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
             }
 
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
-                temp = slapy2_(&workl[iheigr + k - 1], &workl[iheigi + k - 1]);
-                workl[ihbds + k - 1] = (r__1 = workl[ihbds + k - 1], dabs(r__1)) / temp / temp;
+                temp = slapy2_(&workl[iheigr + k], &workl[iheigi + k]);
+                r__1 = workl[ihbds + k];
+                workl[ihbds + k] = dabs(r__1) / temp / temp;
             }
         }
         else if (strcmp(type, "REALPT") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
             }
         }
         else if (strcmp(type, "IMAGPT") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
             }
         }
@@ -958,34 +953,34 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
         if (strcmp(type, "SHIFTI") == 0)
         {
             i__1 = *ncv;
-            for (k = 1; k <= i__1; ++k)
+            for (k = 0; k < i__1; ++k)
             {
-                temp = slapy2_(&workl[iheigr + k - 1], &workl[iheigi + k - 1]);
-                workl[iheigr + k - 1] = workl[iheigr + k - 1] / temp / temp + *sigmar;
-                workl[iheigi + k - 1] = -workl[iheigi + k - 1] / temp / temp + *sigmai;
+                temp = slapy2_(&workl[iheigr + k], &workl[iheigi + k]);
+                workl[iheigr + k] = workl[iheigr + k] / temp / temp + *sigmar;
+                workl[iheigi + k] = -workl[iheigi + k] / temp / temp + *sigmai;
             }
 
-            scopy_(&nconv, &workl[iheigr], &c__1, &dr[1], &c__1);
-            scopy_(&nconv, &workl[iheigi], &c__1, &di[1], &c__1);
+            scopy_(&nconv, &workl[iheigr], &c__1, dr, &c__1);
+            scopy_(&nconv, &workl[iheigi], &c__1, di, &c__1);
         }
         else if (strcmp(type, "REALPT") == 0 || strcmp(type, "IMAGPT") == 0)
         {
-            scopy_(&nconv, &workl[iheigr], &c__1, &dr[1], &c__1);
-            scopy_(&nconv, &workl[iheigi], &c__1, &di[1], &c__1);
+            scopy_(&nconv, &workl[iheigr], &c__1, dr, &c__1);
+            scopy_(&nconv, &workl[iheigi], &c__1, di, &c__1);
         }
     }
 
 #ifndef NO_TRACE
     if (msglvl > 1 && strcmp(type, "SHIFTI") == 0)
     {
-        svout_(&nconv, &dr[1], &debug_1.ndigit, "_neupd: Untransformed float part of the Ritz valuess.");
-        svout_(&nconv, &di[1], &debug_1.ndigit, "_neupd: Untransformed imag part of the Ritz valuess.");
+        svout_(&nconv, dr, &debug_1.ndigit, "_neupd: Untransformed float part of the Ritz valuess.");
+        svout_(&nconv, di, &debug_1.ndigit, "_neupd: Untransformed imag part of the Ritz valuess.");
         svout_(&nconv, &workl[ihbds], &debug_1.ndigit, "_neupd: Ritz estimates of untransformed Ritz values.");
     }
     else if (msglvl > 1 && strcmp(type, "REGULR") == 0)
     {
-        svout_(&nconv, &dr[1], &debug_1.ndigit, "_neupd: Real parts of converged Ritz values.");
-        svout_(&nconv, &di[1], &debug_1.ndigit, "_neupd: Imag parts of converged Ritz values.");
+        svout_(&nconv, dr, &debug_1.ndigit, "_neupd: Real parts of converged Ritz values.");
+        svout_(&nconv, di, &debug_1.ndigit, "_neupd: Imag parts of converged Ritz values.");
         svout_(&nconv, &workl[ihbds], &debug_1.ndigit, "_neupd: Associated Ritz estimates.");
     }
 #endif
@@ -1010,19 +1005,19 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
         /* ---------------------------------------------- */
 
         iconj = 0;
-        for (j = 1; j <= nconv; ++j)
+        for (j = 0; j < nconv; ++j)
         {
-            if (workl[iheigi + j - 1] == 0.0f && workl[iheigr + j - 1] != 0.0f)
+            if (workl[iheigi + j] == 0.0f && workl[iheigr + j] != 0.0f)
             {
-                workev[j] = workl[invsub + (j - 1) * ldq + *ncv - 1] / workl[iheigr + j - 1];
+                workev[j] = workl[invsub + j * ldq + *ncv - 1] / workl[iheigr + j];
             }
             else if (iconj == 0)
             {
-                temp = slapy2_(&workl[iheigr + j - 1], &workl[iheigi + j - 1]);
+                temp = slapy2_(&workl[iheigr + j], &workl[iheigi + j]);
                 if (temp != 0.0f)
                 {
-                    workev[j] = (workl[invsub + (j - 1) * ldq + *ncv - 1] * workl[iheigr + j - 1] + workl[invsub + j * ldq + *ncv - 1] * workl[iheigi + j - 1]) / temp / temp;
-                    workev[j + 1] = (workl[invsub + j * ldq + *ncv - 1] * workl[iheigr + j - 1] - workl[invsub + (j - 1) * ldq + *ncv - 1] * workl[iheigi + j - 1]) / temp / temp;
+                    workev[j] = (workl[invsub + j * ldq + *ncv - 1] * workl[iheigr + j] + workl[invsub + (j + 1) * ldq + *ncv - 1] * workl[iheigi + j]) / temp / temp;
+                    workev[j + 1] = (workl[invsub + (j + 1) * ldq + *ncv - 1] * workl[iheigr + j] - workl[invsub + j * ldq + *ncv - 1] * workl[iheigi + j]) / temp / temp;
                 }
                 iconj = 1;
             }
@@ -1038,7 +1033,7 @@ int sneupd_(bool *rvec, char *howmny, bool *select, float *dr, float *di, float 
         /* purify all the Ritz vectors together. */
         /* ------------------------------------- */
 
-        sger_(n, &nconv, &s_one, &resid[1], &c__1, &workev[1], &c__1, &z[z_offset], ldz);
+        sger_(n, &nconv, &s_one, resid, &c__1, workev, &c__1, &z[z_offset], ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/sngets.c
+++ b/src/ARPACK/arpack-ng/SRC/sngets.c
@@ -107,11 +107,6 @@ int sngets_(int *ishift, char *which, int *kev, int *np, float *ritzr,
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --bounds;
-    --ritzi;
-    --ritzr;
-
     /* Function Body */
 #ifndef NO_TIMER
     arscnd_(&t0);
@@ -133,30 +128,30 @@ int sngets_(int *ishift, char *which, int *kev, int *np, float *ritzr,
 
     if (strcmp(which, "LM") == 0)
     {
-        ssortc_("LR", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        ssortc_("LR", &c_true, &i__1, ritzr, ritzi, bounds);
     }
     else if (strcmp(which, "SM") == 0)
     {
-        ssortc_("SR", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        ssortc_("SR", &c_true, &i__1, ritzr, ritzi, bounds);
     }
     else if (strcmp(which, "LR") == 0)
     {
-        ssortc_("LM", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        ssortc_("LM", &c_true, &i__1, ritzr, ritzi, bounds);
     }
     else if (strcmp(which, "SR") == 0)
     {
-        ssortc_("SM", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        ssortc_("SM", &c_true, &i__1, ritzr, ritzi, bounds);
     }
     else if (strcmp(which, "LI") == 0)
     {
-        ssortc_("LM", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        ssortc_("LM", &c_true, &i__1, ritzr, ritzi, bounds);
     }
     else if (strcmp(which, "SI") == 0)
     {
-        ssortc_("SM", &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+        ssortc_("SM", &c_true, &i__1, ritzr, ritzi, bounds);
     }
 
-    ssortc_(which, &c_true, &i__1, &ritzr[1], &ritzi[1], &bounds[1]);
+    ssortc_(which, &c_true, &i__1, ritzr, ritzi, bounds);
 
     /* ----------------------------------------------------- */
     /* Increase KEV by one if the ( ritzr(np),ritzi(np) )    */
@@ -165,7 +160,7 @@ int sngets_(int *ishift, char *which, int *kev, int *np, float *ritzr,
     /* complex conjugate pairs together.                     */
     /* ----------------------------------------------------- */
 
-    if (ritzr[*np + 1] - ritzr[*np] == 0.0f && ritzi[*np + 1] + ritzi[*np] == 0.0f)
+    if (ritzr[*np] - ritzr[*np - 1] == 0.0f && ritzi[*np] + ritzi[*np - 1] == 0.0f)
     {
         --(*np);
         ++(*kev);
@@ -182,7 +177,7 @@ int sngets_(int *ishift, char *which, int *kev, int *np, float *ritzr,
         /* Be careful and use 'SR' since we want to sort BOUNDS! */
         /* ----------------------------------------------------- */
 
-        ssortc_("SR", &c_true, np, &bounds[1], &ritzr[1], &ritzi[1]);
+        ssortc_("SR", &c_true, np, bounds, ritzr, ritzi);
     }
 
 #ifndef NO_TIMER
@@ -196,9 +191,9 @@ int sngets_(int *ishift, char *which, int *kev, int *np, float *ritzr,
         i__1 = *kev + *np;
         ivout_(&c__1, kev, &debug_1.ndigit, "_ngets: KEV is");
         ivout_(&c__1, np, &debug_1.ndigit, "_ngets: NP is");
-        svout_(&i__1, &ritzr[1], &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix -- float part");
-        svout_(&i__1, &ritzi[1], &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix -- imag part");
-        svout_(&i__1, &bounds[1], &debug_1.ndigit, "_ngets: Ritz estimates of the current KEV+NP Ritz values");
+        svout_(&i__1, ritzr, &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix -- float part");
+        svout_(&i__1, ritzi, &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix -- imag part");
+        svout_(&i__1, bounds, &debug_1.ndigit, "_ngets: Ritz estimates of the current KEV+NP Ritz values");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/ssapps.c
+++ b/src/ARPACK/arpack-ng/SRC/ssapps.c
@@ -153,9 +153,6 @@ int ssapps_(int *n, int *kev, int *np, float *
     int istart, kplusp, msglvl;
 
     /* Parameter adjustments */
-    --workd;
-    --resid;
-    --shift;
     v_dim = *ldv;
     v_offset = 1 + v_dim;
     v -= v_offset;
@@ -263,7 +260,8 @@ L40:
             /* that attempts to drive h(istart+1,1) to zero.          */
             /* ------------------------------------------------------ */
 
-            f = h[istart + (h_dim << 1)] - shift[jj];
+            /* TODO: fix jj - 1 */
+            f = h[istart + (h_dim << 1)] - shift[jj - 1];
             g = h[istart + 1 + h_dim];
             slartg_(&f, &g, &c, &s, &r);
 
@@ -454,7 +452,7 @@ L90:
 
     if (h[*kev + 1 + h_dim] > 0.0f)
     {
-        sgemv_("N", n, &kplusp, &s_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &s_zero, &workd[*n + 1], &c__1);
+        sgemv_("N", n, &kplusp, &s_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &s_zero, &workd[*n], &c__1);
     }
 
     /* ----------------------------------------------------- */
@@ -468,8 +466,8 @@ L90:
     for (i = 1; i <= i__1; ++i)
     {
         i__2 = kplusp - i + 1;
-        sgemv_("N", n, &i__2, &s_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &s_zero, &workd[1], &c__1);
-        scopy_(n, &workd[1], &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
+        sgemv_("N", n, &i__2, &s_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &s_zero, workd, &c__1);
+        scopy_(n, workd, &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------------------- */
@@ -485,7 +483,7 @@ L90:
 
     if (h[*kev + 1 + h_dim] > 0.0f)
     {
-        scopy_(n, &workd[*n + 1], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
+        scopy_(n, &workd[*n], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------- */
@@ -496,10 +494,10 @@ L90:
     /*    betak = e_{kev+1}'*H*e_{kev}     */
     /* ----------------------------------- */
 
-    sscal_(n, &q[kplusp + *kev * q_dim], &resid[1], &c__1);
+    sscal_(n, &q[kplusp + *kev * q_dim], resid, &c__1);
     if (h[*kev + 1 + h_dim] > 0.0f)
     {
-        saxpy_(n, &h[*kev + 1 + h_dim], &v[(*kev + 1) * v_dim + 1], &c__1,&resid[1], &c__1);
+        saxpy_(n, &h[*kev + 1 + h_dim], &v[(*kev + 1) * v_dim + 1], &c__1,resid, &c__1);
     }
 
 #ifndef NO_TRACE

--- a/src/ARPACK/arpack-ng/SRC/ssaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/ssaup2.c
@@ -792,7 +792,7 @@ L50:
     {
         ++timing_1.nbx;
         scopy_(n, resid, &c__1, &workd[*n], &c__1);
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;

--- a/src/ARPACK/arpack-ng/SRC/ssaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/ssaup2.c
@@ -183,8 +183,7 @@ int ssaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
             float *q, int *ldq, float *workl, int *ipntr, float *workd, int *info)
 {
     /* System generated locals */
-    int h_dim, h_offset, q_offset, v_offset, i__1, i__2,
-            i__3;
+    int i__1, i__2, i__3;
     float r__1, r__2, r__3;
 
     /* Builtin functions */
@@ -212,21 +211,6 @@ int ssaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     static bool ushift;
     static int kplusp, msglvl;
     int nptemp;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    --workl;
-    --bounds;
-    --ritz;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    h_dim = *ldh;
-    h_offset = 1 + h_dim;
-    h -= h_offset;
-    q_offset = 1 + *ldq;
-    q -= q_offset;
-    --ipntr;
 
     /* Function Body */
     if (*ido == 0)
@@ -303,7 +287,7 @@ int ssaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
 
     if (getv0)
     {
-        sgetv0_(ido, bmat, &c__1, &initv, n, &c__1, &v[v_offset], ldv, &resid[1], &rnorm, &ipntr[1], &workd[1], info);
+        sgetv0_(ido, bmat, &c__1, &initv, n, &c__1, v, ldv, resid, &rnorm, ipntr, workd, info);
 
         if (*ido != 99)
         {
@@ -355,7 +339,7 @@ int ssaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     /* Compute the first NEV steps of the Lanczos factorization */
     /* -------------------------------------------------------- */
 
-    ssaitr_(ido, bmat, n, &c__0, &nev0, mode, &resid[1], &rnorm, &v[v_offset],ldv, &h[h_offset], ldh, &ipntr[1], &workd[1], info);
+    ssaitr_(ido, bmat, n, &c__0, &nev0, mode, resid, &rnorm, v,ldv, h, ldh, ipntr, workd, info);
 
     /* ------------------------------------------------- */
     /* ido .ne. 99 implies use of reverse communication  */
@@ -414,7 +398,7 @@ L1000:
 L20:
     update = true;
 
-    ssaitr_(ido, bmat, n, nev, np, mode, &resid[1], &rnorm, &v[v_offset], ldv,&h[h_offset], ldh, &ipntr[1], &workd[1], info);
+    ssaitr_(ido, bmat, n, nev, np, mode, resid, &rnorm, v, ldv,h, ldh, ipntr, workd, info);
 
     /* ------------------------------------------------- */
     /* ido .ne. 99 implies use of reverse communication  */
@@ -453,7 +437,7 @@ L20:
     /* of the current symmetric tridiagonal matrix.           */
     /* ------------------------------------------------------ */
 
-    sseigt_(&rnorm, &kplusp, &h[h_offset], ldh, &ritz[1], &bounds[1], &workl[1], &ierr);
+    sseigt_(&rnorm, &kplusp, h, ldh, ritz, bounds, workl, &ierr);
 
     if (ierr != 0)
     {
@@ -466,8 +450,8 @@ L20:
     /* bounds obtained from _seigt.                       */
     /* -------------------------------------------------- */
 
-    scopy_(&kplusp, &ritz[1], &c__1, &workl[kplusp + 1], &c__1);
-    scopy_(&kplusp, &bounds[1], &c__1, &workl[(kplusp << 1) + 1], &c__1);
+    scopy_(&kplusp, ritz, &c__1, &workl[kplusp], &c__1);
+    scopy_(&kplusp, bounds, &c__1, &workl[kplusp << 1], &c__1);
 
     /* ------------------------------------------------- */
     /* Select the wanted Ritz values and their bounds    */
@@ -481,14 +465,14 @@ L20:
 
     *nev = nev0;
     *np = np0;
-    ssgets_(ishift, which, nev, np, &ritz[1], &bounds[1], &workl[1]);
+    ssgets_(ishift, which, nev, np, ritz, bounds, workl);
 
     /* ----------------- */
     /* Convergence test. */
     /* ----------------- */
 
-    scopy_(nev, &bounds[*np + 1], &c__1, &workl[*np + 1], &c__1);
-    ssconv_(nev, &ritz[*np + 1], &workl[*np + 1], tol, &nconv);
+    scopy_(nev, &bounds[*np], &c__1, &workl[*np], &c__1);
+    ssconv_(nev, &ritz[*np], &workl[*np], tol, &nconv);
 
 #ifndef NO_TRACE
     if (msglvl > 2)
@@ -497,8 +481,8 @@ L20:
         kp[1] = *np;
         kp[2] = nconv;
         ivout_(&c__3, kp, &debug_1.ndigit, "_saup2: NEV, NP, NCONV are");
-        svout_(&kplusp, &ritz[1], &debug_1.ndigit, "_saup2: The eigenvalues of H");
-        svout_(&kplusp, &bounds[1], &debug_1.ndigit, "_saup2: Ritz estimates of the current NCV Ritz values");
+        svout_(&kplusp, ritz, &debug_1.ndigit, "_saup2: The eigenvalues of H");
+        svout_(&kplusp, bounds, &debug_1.ndigit, "_saup2: Ritz estimates of the current NCV Ritz values");
     }
 #endif
 
@@ -513,7 +497,7 @@ L20:
     /* ------------------------------------------------------- */
 
     nptemp = *np;
-    for (j = 1; j <= nptemp; ++j)
+    for (j = 0; j < nptemp; ++j)
     {
         if (bounds[j] == 0.0f)
         {
@@ -544,7 +528,7 @@ L20:
             /* --------------------------------------------------- */
 
             strcpy(wprime, "SA");
-            ssortr_(wprime, &c_true, &kplusp, &ritz[1], &bounds[1]);
+            ssortr_(wprime, &c_true, &kplusp, ritz, bounds);
             nevd2 = nev0 / 2;
             nevm2 = nev0 - nevd2;
             if (*nev > 1)
@@ -552,9 +536,9 @@ L20:
                 /* TODO: compare with dsaup2 (update *np = kplusp - nev0) */
                 i__1 = min(nevd2,*np);
                 /* Computing MAX */
-                i__2 = kplusp - nevd2 + 1, i__3 = kplusp - *np + 1;
-                sswap_(&i__1, &ritz[nevm2 + 1], &c__1, &ritz[max(i__2,i__3)], &c__1);
-                sswap_(&i__1, &bounds[nevm2 + 1], &c__1, &bounds[max(i__2,i__3)], &c__1);
+                i__2 = kplusp - nevd2, i__3 = kplusp - *np;
+                sswap_(&i__1, &ritz[nevm2], &c__1, &ritz[max(i__2,i__3)], &c__1);
+                sswap_(&i__1, &bounds[nevm2], &c__1, &bounds[max(i__2,i__3)], &c__1);
             }
         }
         else
@@ -585,7 +569,7 @@ L20:
                 strcpy(wprime, "LA");
             }
 
-            ssortr_(wprime, &c_true, &kplusp, &ritz[1], &bounds[1]);
+            ssortr_(wprime, &c_true, &kplusp, ritz, bounds);
         }
 
         /* ------------------------------------------------ */
@@ -593,7 +577,7 @@ L20:
         /* by 1 / max(eps23,magnitude of the Ritz value).   */
         /* ------------------------------------------------ */
 
-        for (j = 1; j <= nev0; ++j)
+        for (j = 0; j < nev0; ++j)
         {
             /* Computing MAX */
             r__2 = eps23, r__3 = (r__1 = ritz[j], dabs(r__1));
@@ -609,14 +593,14 @@ L20:
         /* -------------------------------------------------- */
 
         strcpy(wprime, "LA");
-        ssortr_(wprime, &c_true, &nev0, &bounds[1], &ritz[1]);
+        ssortr_(wprime, &c_true, &nev0, bounds, ritz);
 
         /* -------------------------------------------- */
         /* Scale the Ritz estimate back to its original */
         /* value.                                       */
         /* -------------------------------------------- */
 
-        for (j = 1; j <= nev0; ++j)
+        for (j = 0; j < nev0; ++j)
         {
             /* Computing MAX */
             r__2 = eps23, r__3 = (r__1 = ritz[j], dabs(r__1));
@@ -640,7 +624,7 @@ L20:
             /* ---------------------------------------------- */
 
             strcpy(wprime, "LA");
-            ssortr_(wprime, &c_true, &nconv, &ritz[1], &bounds[1]);
+            ssortr_(wprime, &c_true, &nconv, ritz, bounds);
         }
         else
         {
@@ -650,7 +634,7 @@ L20:
             /* "threshold" value appears at the front of    */
             /* ritz.                                        */
             /* -------------------------------------------- */
-            ssortr_(which, &c_true, &nconv, &ritz[1], &bounds[1]);
+            ssortr_(which, &c_true, &nconv, ritz, bounds);
         }
 
         /* ---------------------------------------- */
@@ -658,13 +642,13 @@ L20:
         /*  rnorm to _seupd if needed               */
         /* ---------------------------------------- */
 
-        h[h_dim + 1] = rnorm;
+        h[0] = rnorm;
 
 #ifndef NO_TRACE
         if (msglvl > 1)
         {
-            svout_(&kplusp, &ritz[1], &debug_1.ndigit, "_saup2: Sorted Ritz values.");
-            svout_(&kplusp, &bounds[1], &debug_1.ndigit, "_saup2: Sorted ritz estimates.");
+            svout_(&kplusp, ritz, &debug_1.ndigit, "_saup2: Sorted Ritz values.");
+            svout_(&kplusp, bounds, &debug_1.ndigit, "_saup2: Sorted ritz estimates.");
         }
 #endif
 
@@ -718,7 +702,7 @@ L20:
 
         if (nevbef < *nev)
         {
-            ssgets_(ishift, which, nev, np, &ritz[1], &bounds[1], &workl[1]);
+            ssgets_(ishift, which, nev, np, ritz, bounds, workl);
         }
     }
 
@@ -731,8 +715,8 @@ L20:
             kp[0] = *nev;
             kp[1] = *np;
             ivout_(&c__2, kp, &debug_1.ndigit, "_saup2: NEV and NP are");
-            svout_(nev, &ritz[*np + 1], &debug_1.ndigit, "_saup2: \"wanted\" Ritz values.");
-            svout_(nev, &bounds[*np + 1], &debug_1.ndigit, "_saup2: Ritz estimates of the \"wanted\" values ");
+            svout_(nev, &ritz[*np], &debug_1.ndigit, "_saup2: \"wanted\" Ritz values.");
+            svout_(nev, &bounds[*np], &debug_1.ndigit, "_saup2: Ritz estimates of the \"wanted\" values ");
         }
     }
 #endif
@@ -768,17 +752,17 @@ L50:
 
     if (*ishift == 0)
     {
-        scopy_(np, &workl[1], &c__1, &ritz[1], &c__1);
+        scopy_(np, workl, &c__1, ritz, &c__1);
     }
 
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
         ivout_(&c__1, np, &debug_1.ndigit, "_saup2: The number of shifts to apply ");
-        svout_(np, &workl[1], &debug_1.ndigit, "_saup2: shifts selected");
+        svout_(np, workl, &debug_1.ndigit, "_saup2: shifts selected");
         if (*ishift == 1)
         {
-            svout_(np, &bounds[1], &debug_1.ndigit, "_saup2: corresponding Ritz estimates");
+            svout_(np, bounds, &debug_1.ndigit, "_saup2: corresponding Ritz estimates");
         }
     }
 #endif
@@ -791,7 +775,7 @@ L50:
     /* factorization of length NEV.                            */
     /* ------------------------------------------------------- */
 
-    ssapps_(n, nev, np, &ritz[1], &v[v_offset], ldv, &h[h_offset], ldh, &resid[1], &q[q_offset], ldq, &workd[1]);
+    ssapps_(n, nev, np, ritz, v, ldv, h, ldh, resid, q, ldq, workd);
 
     /* ------------------------------------------- */
     /* Compute the B-norm of the updated residual. */
@@ -807,9 +791,10 @@ L50:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        scopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        scopy_(n, resid, &c__1, &workd[*n], &c__1);
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
 
         /* -------------------------------- */
@@ -820,7 +805,7 @@ L50:
     }
     else if (*bmat == 'I')
     {
-        scopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        scopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L100:
@@ -836,12 +821,12 @@ L100:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        rnorm = sdot_(n, &resid[1], &c__1, &workd[1], &c__1);
+        rnorm = sdot_(n, resid, &c__1, workd, &c__1);
         rnorm = sqrt((dabs(rnorm)));
     }
     else if (*bmat == 'I')
     {
-        rnorm = snrm2_(n, &resid[1], &c__1);
+        rnorm = snrm2_(n, resid, &c__1);
     }
     cnorm = false;
 
@@ -850,9 +835,9 @@ L100:
     if (msglvl > 2)
     {
         svout_(&c__1, &rnorm, &debug_1.ndigit, "_saup2: B-norm of residual for NEV factorization");
-        svout_(nev, &h[(h_dim << 1) + 1], &debug_1.ndigit,"_saup2: main diagonal of compressed H matrix");
+        svout_(nev, &h[*ldh], &debug_1.ndigit,"_saup2: main diagonal of compressed H matrix");
         i__1 = *nev - 1;
-        svout_(&i__1, &h[h_dim + 2], &debug_1.ndigit, "_saup2: subdiagonal of compressed H matrix");
+        svout_(&i__1, &h[1], &debug_1.ndigit, "_saup2: subdiagonal of compressed H matrix");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/ssaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/ssaupd.c
@@ -413,7 +413,7 @@ int ssaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 {
 
     /* System generated locals */
-    int v_offset, i__1, i__2;
+    int i__1, i__2;
 
     /* Local variables */
     int j, ierr;
@@ -424,20 +424,10 @@ int ssaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 
     int ldh = *ncv;
     int ldq = *ncv;
-    int ih = 1;
-    int ritz = ih + (ldh << 1);
+    int ritz = ldh << 1;
     int bounds = ritz + *ncv;
     int iq = bounds + *ncv;
     int iw = iq + *ncv * *ncv;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    --iparam;
-    --ipntr;
-    --workl;
 
     /* Function Body */
     if (*ido == 0)
@@ -453,15 +443,15 @@ int ssaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 #endif
 
         ierr = 0;
-        ishift = iparam[1];
-        mxiter = iparam[3];
-        /*         nb     = iparam(4) */
+        ishift = iparam[0];
+        mxiter = iparam[2];
+        /* nb     = iparam(4) */
 
         /* ------------------------------------------ */
         /* Revision 2 performs only implicit restart. */
         /* ------------------------------------------ */
 
-        mode = iparam[7];
+        mode = iparam[6];
 
         /* -------------- */
         /* Error checking */
@@ -562,7 +552,7 @@ int ssaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
         /* Computing 2nd power */
         i__2 = *ncv;
         i__1 = i__2 * i__2 + (*ncv << 3);
-        for (j = 1; j <= i__1; ++j)
+        for (j = 0; j < i__1; ++j)
         {
             workl[j] = 0.0f;
         }
@@ -581,18 +571,19 @@ int ssaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 
 
         /* Computing 2nd power */
-        ipntr[4] = iw + *ncv * 3;
-        ipntr[5] = ih;
-        ipntr[6] = ritz;
-        ipntr[7] = bounds;
-        ipntr[11] = iw;
+        /* TODO: subtract 1 !!! */
+        ipntr[3] = 1 + iw + *ncv * 3;
+        ipntr[4] = 1;
+        ipntr[5] = 1 + ritz;
+        ipntr[6] = 1 + bounds;
+        ipntr[10] = 1 + iw;
     }
 
     /* ----------------------------------------------------- */
     /* Carry out the Implicitly restarted Lanczos Iteration. */
     /* ----------------------------------------------------- */
 
-    ssaup2_(ido, bmat, n, which, &nev0, &np, tol, &resid[1], &mode, &iupd, &ishift, &mxiter, &v[v_offset], ldv, &workl[ih], &ldh, &workl[ritz], &workl[bounds], &workl[iq], &ldq, &workl[iw], &ipntr[1], &workd[1], info);
+    ssaup2_(ido, bmat, n, which, &nev0, &np, tol, resid, &mode, &iupd, &ishift, &mxiter, v, ldv, workl, &ldh, &workl[ritz], &workl[bounds], &workl[iq], &ldq, &workl[iw], ipntr, workd, info);
 
     /* ------------------------------------------------ */
     /* ido .ne. 99 implies use of reverse communication */
@@ -601,18 +592,18 @@ int ssaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
 
     if (*ido == 3)
     {
-        iparam[8] = np;
+        iparam[7] = np;
     }
     if (*ido != 99)
     {
         goto L9000;
     }
 
-    iparam[3] = mxiter;
-    iparam[5] = np;
-    iparam[9] = timing_1.nopx;
-    iparam[10] = timing_1.nbx;
-    iparam[11] = timing_1.nrorth;
+    iparam[2] = mxiter;
+    iparam[4] = np;
+    iparam[8] = timing_1.nopx;
+    iparam[9] = timing_1.nbx;
+    iparam[10] = timing_1.nrorth;
 
     /* ---------------------------------- */
     /* Exit if there was an informational */

--- a/src/ARPACK/arpack-ng/SRC/ssaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/ssaupd.c
@@ -570,8 +570,7 @@ int ssaupd_(int *ido, char *bmat, int *n, char *which, int *nev, float *tol,
         /* ----------------------------------------------------- */
 
 
-        /* Computing 2nd power */
-        /* TODO: subtract 1 !!! */
+        /* TODO: ipntr index */
         ipntr[3] = 1 + iw + *ncv * 3;
         ipntr[4] = 1;
         ipntr[5] = 1 + ritz;

--- a/src/ARPACK/arpack-ng/SRC/sseigt.c
+++ b/src/ARPACK/arpack-ng/SRC/sseigt.c
@@ -88,7 +88,7 @@ int sseigt_(float *rnorm, int *n, float *h, int *ldh,
             float *eig, float *bounds, float *workl, int *ierr)
 {
     /* System generated locals */
-    int h_dim, h_offset, i__1;
+    int h_dim, i__1;
     float r__1;
 
     /* Local variables */
@@ -96,20 +96,12 @@ int sseigt_(float *rnorm, int *n, float *h, int *ldh,
     static float t0, t1;
     int msglvl;
 
-
     /* ----------------------------- */
     /* Initialize timing statistics  */
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --workl;
-    --bounds;
-    --eig;
     h_dim = *ldh;
-    h_offset = 1 + h_dim;
-    h -= h_offset;
-
     /* Function Body */
 #ifndef NO_TIMER
     arscnd_(&t0);
@@ -120,19 +112,19 @@ int sseigt_(float *rnorm, int *n, float *h, int *ldh,
 #ifndef NO_TRACE
     if (msglvl > 0)
     {
-        svout_(n, &h[(h_dim << 1) + 1], &debug_1.ndigit, "_seigt: main diagonal of matrix H");
+        svout_(n, &h[h_dim], &debug_1.ndigit, "_seigt: main diagonal of matrix H");
         if (*n > 1)
         {
             i__1 = *n - 1;
-            svout_(&i__1, &h[h_dim + 2], &debug_1.ndigit, "_seigt: sub diagonal of matrix H");
+            svout_(&i__1, &h[1], &debug_1.ndigit, "_seigt: sub diagonal of matrix H");
         }
     }
 #endif
 
-    scopy_(n, &h[(h_dim << 1) + 1], &c__1, &eig[1], &c__1);
+    scopy_(n, &h[h_dim], &c__1, eig, &c__1);
     i__1 = *n - 1;
-    scopy_(&i__1, &h[h_dim + 2], &c__1, &workl[1], &c__1);
-    sstqrb_(n, &eig[1], &workl[1], &bounds[1], &workl[*n + 1], ierr);
+    scopy_(&i__1, &h[1], &c__1, workl, &c__1);
+    sstqrb_(n, eig, workl, bounds, &workl[*n], ierr);
     if (*ierr != 0)
     {
         goto L9000;
@@ -140,7 +132,7 @@ int sseigt_(float *rnorm, int *n, float *h, int *ldh,
 #ifndef NO_TRACE
     if (msglvl > 1)
     {
-        svout_(n, &bounds[1], &debug_1.ndigit, "_seigt: last row of the eigenvector matrix for H");
+        svout_(n, bounds, &debug_1.ndigit, "_seigt: last row of the eigenvector matrix for H");
     }
 #endif
 
@@ -150,7 +142,7 @@ int sseigt_(float *rnorm, int *n, float *h, int *ldh,
     /* --------------------------------------------- */
 
     i__1 = *n;
-    for (k = 1; k <= i__1; ++k)
+    for (k = 0; k < i__1; ++k)
     {
         bounds[k] = *rnorm * (r__1 = bounds[k], dabs(r__1));
     }

--- a/src/ARPACK/arpack-ng/SRC/sseupd.c
+++ b/src/ARPACK/arpack-ng/SRC/sseupd.c
@@ -248,22 +248,17 @@ int sseupd_(bool *rvec, char *howmny, bool *select, float *d, float *z, int *ldz
 
 
     /* Parameter adjustments */
-    --workd;
-    --resid;
     z_offset = 1 + *ldz;
     z -= z_offset;
-    --d;
-    --select;
     v_offset = 1 + *ldv;
     v -= v_offset;
-    --iparam;
-    --ipntr;
+    --select;
     --workl;
 
     /* Function Body */
     msglvl = debug_1.mseupd;
-    mode = iparam[7];
-    nconv = iparam[5];
+    mode = iparam[6];
+    nconv = iparam[4];
     *info = 0;
 
     /* ------------ */
@@ -400,9 +395,9 @@ int sseupd_(bool *rvec, char *howmny, bool *select, float *d, float *z, int *ldz
     /* GRAND total of NCV*(NCV+8) locations.                 */
     /* ----------------------------------------------------- */
 
-    ih = ipntr[5];
-    ritz = ipntr[6];
-    bounds = ipntr[7];
+    ih = ipntr[4];
+    ritz = ipntr[5];
+    bounds = ipntr[6];
     ldh = *ncv;
     ldq = *ncv;
     ihd = bounds + ldh;
@@ -410,10 +405,10 @@ int sseupd_(bool *rvec, char *howmny, bool *select, float *d, float *z, int *ldz
     iq = ihb + ldh;
     iw = iq + ldh * *ncv;
     next = iw + (*ncv << 1);
-    ipntr[4] = next;
-    ipntr[8] = ihd;
-    ipntr[9] = ihb;
-    ipntr[10] = iq;
+    ipntr[3] = next;
+    ipntr[7] = ihd;
+    ipntr[8] = ihb;
+    ipntr[9] = iq;
 
     /* -------------------------------------- */
     /* irz points to the Ritz values computed */
@@ -423,7 +418,7 @@ int sseupd_(bool *rvec, char *howmny, bool *select, float *d, float *z, int *ldz
     /*     _saup2.                            */
     /* -------------------------------------- */
 
-    irz = ipntr[11] + *ncv;
+    irz = ipntr[10] + *ncv;
     ibd = irz + *ncv;
 
     /* ------------------------------- */
@@ -447,7 +442,7 @@ int sseupd_(bool *rvec, char *howmny, bool *select, float *d, float *z, int *ldz
     }
     else if (*bmat == 'G')
     {
-        bnorm2 = snrm2_(n, &workd[1], &c__1);
+        bnorm2 = snrm2_(n, workd, &c__1);
     }
 
 #ifndef NO_TRACE
@@ -644,7 +639,7 @@ L30:
         /* Load the converged Ritz values into D. */
         /* -------------------------------------- */
 
-        scopy_(&nconv, &workl[ihd], &c__1, &d[1], &c__1);
+        scopy_(&nconv, &workl[ihd], &c__1, d, &c__1);
     }
     else
     {
@@ -652,7 +647,7 @@ L30:
         /* Ritz vectors not required. Load Ritz values into D. */
         /* --------------------------------------------------- */
 
-        scopy_(&nconv, &workl[ritz], &c__1, &d[1], &c__1);
+        scopy_(&nconv, &workl[ritz], &c__1, d, &c__1);
         scopy_(ncv, &workl[ritz], &c__1, &workl[ihd], &c__1);
     }
 
@@ -671,7 +666,7 @@ L30:
 
         if (*rvec)
         {
-            ssesrt_("LA", rvec, &nconv, &d[1], ncv, &workl[iq], &ldq);
+            ssesrt_("LA", rvec, &nconv, d, ncv, &workl[iq], &ldq);
         }
         else
         {
@@ -736,18 +731,18 @@ L30:
         /*  Ritz vector purification.                                  */
         /* ----------------------------------------------------------- */
 
-        scopy_(&nconv, &workl[ihd], &c__1, &d[1], &c__1);
+        scopy_(&nconv, &workl[ihd], &c__1, d, &c__1);
         ssortr_("LA", &c_true, &nconv, &workl[ihd], &workl[iw]);
         if (*rvec)
         {
-            ssesrt_("LA", rvec, &nconv, &d[1], ncv, &workl[iq], &ldq);
+            ssesrt_("LA", rvec, &nconv, d, ncv, &workl[iq], &ldq);
         }
         else
         {
             scopy_(ncv, &workl[bounds], &c__1, &workl[ihb], &c__1);
             r__1 = bnorm2 / rnorm;
             sscal_(ncv, &r__1, &workl[ihb], &c__1);
-            ssortr_("LA", &c_true, &nconv, &d[1], &workl[ihb]);
+            ssortr_("LA", &c_true, &nconv, d, &workl[ihb]);
         }
     }
 
@@ -775,7 +770,7 @@ L30:
         /* the Ritz values in workl(ihd).                         */
         /* ------------------------------------------------------ */
 
-        sorm2r_("R", "N", n, ncv, &nconv, &workl[iq], &ldq, &workl[iw + *ncv], &v[v_offset], ldv, &workd[*n + 1], &ierr);
+        sorm2r_("R", "N", n, ncv, &nconv, &workl[iq], &ldq, &workl[iw + *ncv], &v[v_offset], ldv, &workd[*n], &ierr);
         slacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
 
         /* --------------------------------------------------- */
@@ -861,12 +856,12 @@ L30:
 #ifndef NO_TRACE
     if (msglvl > 1 && strcmp(type, "REGULR") != 0)
     {
-        svout_(&nconv, &d[1], &debug_1.ndigit, "_seupd: Untransformed converged Ritz values");
+        svout_(&nconv, d, &debug_1.ndigit, "_seupd: Untransformed converged Ritz values");
         svout_(&nconv, &workl[ihb], &debug_1.ndigit, "_seupd: Ritz estimates of the untransformed Ritz values");
     }
     else if (msglvl > 1)
     {
-        svout_(&nconv, &d[1], &debug_1.ndigit, "_seupd: Converged Ritz values");
+        svout_(&nconv, d, &debug_1.ndigit, "_seupd: Converged Ritz values");
         svout_(&nconv, &workl[ihb], &debug_1.ndigit, "_seupd: Associated Ritz estimates");
     }
 #endif
@@ -896,7 +891,7 @@ L30:
 
     if (strcmp(type, "REGULR") != 0)
     {
-        sger_(n, &nconv, &s_one, &resid[1], &c__1, &workl[iw], &c__1, &z[z_offset], ldz);
+        sger_(n, &nconv, &s_one, resid, &c__1, &workl[iw], &c__1, &z[z_offset], ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/sseupd.c
+++ b/src/ARPACK/arpack-ng/SRC/sseupd.c
@@ -225,7 +225,7 @@ int sseupd_(bool *rvec, char *howmny, bool *select, float *d, float *z, int *ldz
             float *workd, float *workl, int *lworkl, int *info)
 {
     /* System generated locals */
-    int v_offset, z_offset, i__1;
+    int i__1;
     float r__1, r__2, r__3;
 
     /* Builtin functions */
@@ -248,10 +248,6 @@ int sseupd_(bool *rvec, char *howmny, bool *select, float *d, float *z, int *ldz
 
 
     /* Parameter adjustments */
-    z_offset = 1 + *ldz;
-    z -= z_offset;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
     --select;
     --workl;
 
@@ -770,8 +766,8 @@ L30:
         /* the Ritz values in workl(ihd).                         */
         /* ------------------------------------------------------ */
 
-        sorm2r_("R", "N", n, ncv, &nconv, &workl[iq], &ldq, &workl[iw + *ncv], &v[v_offset], ldv, &workd[*n], &ierr);
-        slacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
+        sorm2r_("R", "N", n, ncv, &nconv, &workl[iq], &ldq, &workl[iw + *ncv], v, ldv, &workd[*n], &ierr);
+        slacpy_("A", n, &nconv, v, ldv, z, ldz);
 
         /* --------------------------------------------------- */
         /* In order to compute the Ritz estimates for the Ritz */
@@ -891,7 +887,7 @@ L30:
 
     if (strcmp(type, "REGULR") != 0)
     {
-        sger_(n, &nconv, &s_one, resid, &c__1, &workl[iw], &c__1, &z[z_offset], ldz);
+        sger_(n, &nconv, &s_one, resid, &c__1, &workl[iw], &c__1, z, ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/ssgets.c
+++ b/src/ARPACK/arpack-ng/SRC/ssgets.c
@@ -107,11 +107,6 @@ int ssgets_(int *ishift, char *which, int *kev, int *np, float *ritz,
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --shifts;
-    --bounds;
-    --ritz;
-
     /* Function Body */
 #ifndef NO_TIMER
     arscnd_(&t0);
@@ -131,13 +126,13 @@ int ssgets_(int *ishift, char *which, int *kev, int *np, float *ritz,
         /* --------------------------------------------------- */
 
         i__1 = *kev + *np;
-        ssortr_("LA", &c_true, &i__1, &ritz[1], &bounds[1]);
+        ssortr_("LA", &c_true, &i__1, ritz, bounds);
         kevd2 = *kev / 2;
         if (*kev > 1)
         {
             i__1 = min(kevd2,*np);
-            sswap_(&i__1, &ritz[1], &c__1, &ritz[max(kevd2,*np) + 1], &c__1);
-            sswap_(&i__1, &bounds[1], &c__1, &bounds[max(kevd2,*np) + 1], &c__1);
+            sswap_(&i__1, ritz, &c__1, &ritz[max(kevd2,*np)], &c__1);
+            sswap_(&i__1, bounds, &c__1, &bounds[max(kevd2,*np)], &c__1);
         }
     }
     else
@@ -151,7 +146,7 @@ int ssgets_(int *ishift, char *which, int *kev, int *np, float *ritz,
         /* -------------------------------------------------- */
 
         i__1 = *kev + *np;
-        ssortr_(which, &c_true, &i__1, &ritz[1], &bounds[1]);
+        ssortr_(which, &c_true, &i__1, ritz, bounds);
     }
 
     if (*ishift == 1 && *np > 0)
@@ -164,8 +159,8 @@ int ssgets_(int *ishift, char *which, int *kev, int *np, float *ritz,
         /* are applied in subroutine ssapps.                     */
         /* ----------------------------------------------------- */
 
-        ssortr_("SM", &c_true, np, &bounds[1], &ritz[1]);
-        scopy_(np, &ritz[1], &c__1, &shifts[1], &c__1);
+        ssortr_("SM", &c_true, np, bounds, ritz);
+        scopy_(np, ritz, &c__1, shifts, &c__1);
     }
 
 #ifndef NO_TIMER
@@ -179,8 +174,8 @@ int ssgets_(int *ishift, char *which, int *kev, int *np, float *ritz,
         i__1 = *kev + *np;
         ivout_(&c__1, kev, &debug_1.ndigit, "_sgets: KEV is");
         ivout_(&c__1, np, &debug_1.ndigit, "_sgets: NP is");
-        svout_(&i__1, &ritz[1], &debug_1.ndigit, "_sgets: Eigenvalues of current H matrix");
-        svout_(&i__1, &bounds[1], &debug_1.ndigit, "_sgets: Associated Ritz estimates");
+        svout_(&i__1, ritz, &debug_1.ndigit, "_sgets: Eigenvalues of current H matrix");
+        svout_(&i__1, bounds, &debug_1.ndigit, "_sgets: Associated Ritz estimates");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/zgetv0.c
+++ b/src/ARPACK/arpack-ng/SRC/zgetv0.c
@@ -203,7 +203,7 @@ int zgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (*itry == 1)
         {
             ++timing_1.nopx;
-            /* TODO: subtract 1 */
+            /* TODO: ipntr index */
             ipntr[0] = 1;
             ipntr[1] = *n + 1;
             zcopy_(n, resid, &c__1, workd, &c__1);
@@ -256,7 +256,7 @@ int zgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;
@@ -333,7 +333,7 @@ L30:
     {
         ++timing_1.nbx;
         zcopy_(n, resid, &c__1, &workd[*n], &c__1);
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;

--- a/src/ARPACK/arpack-ng/SRC/zgetv0.c
+++ b/src/ARPACK/arpack-ng/SRC/zgetv0.c
@@ -122,7 +122,7 @@ int zgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     static bool inits = true;
 
     /* System generated locals */
-    int v_offset, i__1;
+    int i__1;
     double d__1, d__2;
     zomplex z__1;
 
@@ -140,13 +140,6 @@ int zgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     static bool first;
     static double rnorm0;
     static int msglvl;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    --ipntr;
 
     /* Function Body */
 
@@ -195,7 +188,7 @@ int zgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (! (*initv))
         {
             idist = 2;
-            zlarnv_(&idist, iseed, n, &resid[1]);
+            zlarnv_(&idist, iseed, n, resid);
         }
 
         /* -------------------------------------------------------- */
@@ -210,15 +203,16 @@ int zgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
         if (*itry == 1)
         {
             ++timing_1.nopx;
-            ipntr[1] = 1;
-            ipntr[2] = *n + 1;
-            zcopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+            /* TODO: subtract 1 */
+            ipntr[0] = 1;
+            ipntr[1] = *n + 1;
+            zcopy_(n, resid, &c__1, workd, &c__1);
             *ido = -1;
             goto L9000;
         }
         else if (*itry > 1 && *bmat == 'G')
         {
-            zcopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
+            zcopy_(n, resid, &c__1, &workd[*n], &c__1);
         }
     }
 
@@ -257,19 +251,20 @@ int zgetv0_(int *ido, char *bmat, int *itry, bool *initv, int *n, int *j,
     first = true;
     if (*itry == 1)
     {
-        zcopy_(n, &workd[*n + 1], &c__1, &resid[1], &c__1);
+        zcopy_(n, &workd[*n], &c__1, resid, &c__1);
     }
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
         goto L9000;
     }
     else if (*bmat == 'I')
     {
-        zcopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        zcopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L20:
@@ -285,7 +280,7 @@ L20:
     first = false;
     if (*bmat == 'G')
     {
-        zdotc_(&z__1, n, &resid[1], &c__1, &workd[1], &c__1);
+        zdotc_(&z__1, n, resid, &c__1, workd, &c__1);
         cnorm.r = z__1.r, cnorm.i = z__1.i;
         d__1 = cnorm.r;
         d__2 = cnorm.i;
@@ -293,7 +288,7 @@ L20:
     }
     else if (*bmat == 'I')
     {
-        rnorm0 = dznrm2_(n, &resid[1], &c__1);
+        rnorm0 = dznrm2_(n, resid, &c__1);
     }
     *rnorm = rnorm0;
 
@@ -322,9 +317,9 @@ L20:
 L30:
 
     i__1 = *j - 1;
-    zgemv_("C", n, &i__1, &z_one, &v[v_offset], ldv, &workd[1], &c__1, &z_zero, &workd[*n + 1], &c__1);
+    zgemv_("C", n, &i__1, &z_one, v, ldv, workd, &c__1, &z_zero, &workd[*n], &c__1);
     z__1.r = -1., z__1.i = -0.0;
-    zgemv_("N", n, &i__1, &z__1, &v[v_offset], ldv, &workd[*n + 1], &c__1, &z_one, &resid[1], &c__1);
+    zgemv_("N", n, &i__1, &z__1, v, ldv, &workd[*n], &c__1, &z_one, resid, &c__1);
 
     /* -------------------------------------------------------- */
     /* Compute the B-norm of the orthogonalized starting vector */
@@ -337,15 +332,16 @@ L30:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        zcopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        zcopy_(n, resid, &c__1, &workd[*n], &c__1);
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
         goto L9000;
     }
     else if (*bmat == 'I')
     {
-        zcopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        zcopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L40:
@@ -356,7 +352,7 @@ L40:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        zdotc_(&z__1, n, &resid[1], &c__1, &workd[1], &c__1);
+        zdotc_(&z__1, n, resid, &c__1, workd, &c__1);
         cnorm.r = z__1.r, cnorm.i = z__1.i;
         d__1 = cnorm.r;
         d__2 = cnorm.i;
@@ -364,7 +360,7 @@ L40:
     }
     else if (*bmat == 'I')
     {
-        *rnorm = dznrm2_(n, &resid[1], &c__1);
+        *rnorm = dznrm2_(n, resid, &c__1);
     }
 
     /* ------------------------------------ */
@@ -401,7 +397,7 @@ L40:
         /* ---------------------------------- */
 
         i__1 = *n;
-        for (jj = 1; jj <= i__1; ++jj)
+        for (jj = 0; jj < i__1; ++jj)
         {
             resid[jj].r = 0.0, resid[jj].i = 0.0;
         }
@@ -419,7 +415,7 @@ L50:
 
     if (msglvl > 2)
     {
-        zvout_(n, &resid[1], &debug_1.ndigit, "_getv0: initial / restarted starting vector");
+        zvout_(n, resid, &debug_1.ndigit, "_getv0: initial / restarted starting vector");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/znaitr.c
+++ b/src/ARPACK/arpack-ng/SRC/znaitr.c
@@ -250,14 +250,12 @@ int znaitr_(int *ido, char *bmat, int *n, int *k,int *np, int *nb,
 
     /* Parameter adjustments */
     --workd;
-    --resid;
     v_dim = *ldv;
     v_offset = 1 + v_dim;
     v -= v_offset;
     h_dim = *ldh;
     h_offset = 1 + h_dim;
     h -= h_offset;
-    --ipntr;
 
     /* Function Body */
 
@@ -404,7 +402,7 @@ L30:
     /* RSTART = .true. flow returns here.   */
     /* ------------------------------------ */
 
-    zgetv0_(ido, bmat, &itry, &c_false, n, &j, &v[v_offset], ldv, &resid[1], rnorm, &ipntr[1], &workd[1], &ierr);
+    zgetv0_(ido, bmat, &itry, &c_false, n, &j, &v[v_offset], ldv, resid, rnorm, ipntr, &workd[1], &ierr);
     if (*ido != 99)
     {
         goto L9000;
@@ -442,7 +440,7 @@ L40:
     /* machine bound.                                          */
     /* ------------------------------------------------------- */
 
-    zcopy_(n, &resid[1], &c__1, &v[j * v_dim + 1], &c__1);
+    zcopy_(n, resid, &c__1, &v[j * v_dim + 1], &c__1);
     if (*rnorm >= unfl)
     {
         temp1 = 1.0 / *rnorm;
@@ -472,9 +470,9 @@ L40:
 #endif
 
     zcopy_(n, &v[j * v_dim + 1], &c__1, &workd[ivj], &c__1);
-    ipntr[1] = ivj;
-    ipntr[2] = irj;
-    ipntr[3] = ipj;
+    ipntr[0] = ivj;
+    ipntr[1] = irj;
+    ipntr[2] = ipj;
     *ido = 1;
 
     /* --------------------------------- */
@@ -501,7 +499,7 @@ L50:
     /* Put another copy of OP*v_{j} into RESID. */
     /* ---------------------------------------- */
 
-    zcopy_(n, &workd[irj], &c__1, &resid[1], &c__1);
+    zcopy_(n, &workd[irj], &c__1, resid, &c__1);
 
     /* ------------------------------------- */
     /* STEP 4:  Finish extending the Arnoldi */
@@ -516,8 +514,8 @@ L50:
     {
         ++timing_1.nbx;
         step4 = true;
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* ----------------------------------- */
@@ -528,7 +526,7 @@ L50:
     }
     else if (*bmat == 'I')
     {
-        zcopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        zcopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L60:
 
@@ -555,13 +553,13 @@ L60:
 
     if (*bmat == 'G')
     {
-        zdotc_(&z__1, n, &resid[1], &c__1, &workd[ipj], &c__1);
+        zdotc_(&z__1, n, resid, &c__1, &workd[ipj], &c__1);
         cnorm.r = z__1.r, cnorm.i = z__1.i;
         wnorm = sqrt(dlapy2_(&cnorm.r, &cnorm.i));
     }
     else if (*bmat == 'I')
     {
-        wnorm = dznrm2_(n, &resid[1], &c__1);
+        wnorm = dznrm2_(n, resid, &c__1);
     }
 
     /* --------------------------------------- */
@@ -584,14 +582,14 @@ L60:
     /* RESID contains OP*v_{j}. See STEP 3. */
     /* ------------------------------------ */
 
-    z__1.r = -1., z__1.i = -0.0;
-    zgemv_("N", n, &j, &z__1, &v[v_offset], ldv, &h[j * h_dim + 1], &c__1, &z_one, &resid[1], &c__1);
+    z__1.r = -1.0, z__1.i = -0.0;
+    zgemv_("N", n, &j, &z__1, &v[v_offset], ldv, &h[j * h_dim + 1], &c__1, &z_one, resid, &c__1);
 
     if (j > 1)
     {
         i__1 = j + (j - 1) * h_dim;
-        z__1.r = betaj, z__1.i = 0.0;
-        h[i__1].r = z__1.r, h[i__1].i = z__1.i;
+        h[i__1].r = betaj;
+        h[i__1].i = 0.0;
     }
 
 #ifndef NO_TIMER
@@ -604,9 +602,9 @@ L60:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        zcopy_(n, &resid[1], &c__1, &workd[irj], &c__1);
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        zcopy_(n, resid, &c__1, &workd[irj], &c__1);
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* -------------------------------- */
@@ -617,7 +615,7 @@ L60:
     }
     else if (*bmat == 'I')
     {
-        zcopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        zcopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L70:
 
@@ -642,13 +640,13 @@ L70:
 
     if (*bmat == 'G')
     {
-        zdotc_(&z__1, n, &resid[1], &c__1, &workd[ipj], &c__1);
+        zdotc_(&z__1, n, resid, &c__1, &workd[ipj], &c__1);
         cnorm.r = z__1.r, cnorm.i = z__1.i;
         *rnorm = sqrt(dlapy2_(&cnorm.r, &cnorm.i));
     }
     else if (*bmat == 'I')
     {
-        *rnorm = dznrm2_(n, &resid[1], &c__1);
+        *rnorm = dznrm2_(n, resid, &c__1);
     }
 
     /* --------------------------------------------------------- */
@@ -711,7 +709,7 @@ L80:
     /* ------------------------------------------- */
 
     z__1.r = -1., z__1.i = -0.0;
-    zgemv_("N", n, &j, &z__1, &v[v_offset], ldv, &workd[irj], &c__1, &z_one, &resid[1], &c__1);
+    zgemv_("N", n, &j, &z__1, &v[v_offset], ldv, &workd[irj], &c__1, &z_one, resid, &c__1);
     zaxpy_(&j, &z_one, &workd[irj], &c__1, &h[j * h_dim + 1], &c__1);
 
     orth2 = true;
@@ -722,9 +720,9 @@ L80:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        zcopy_(n, &resid[1], &c__1, &workd[irj], &c__1);
-        ipntr[1] = irj;
-        ipntr[2] = ipj;
+        zcopy_(n, resid, &c__1, &workd[irj], &c__1);
+        ipntr[0] = irj;
+        ipntr[1] = ipj;
         *ido = 2;
 
         /* --------------------------------- */
@@ -736,7 +734,7 @@ L80:
     }
     else if (*bmat == 'I')
     {
-        zcopy_(n, &resid[1], &c__1, &workd[ipj], &c__1);
+        zcopy_(n, resid, &c__1, &workd[ipj], &c__1);
     }
 L90:
 
@@ -754,13 +752,13 @@ L90:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        zdotc_(&z__1, n, &resid[1], &c__1, &workd[ipj], &c__1);
+        zdotc_(&z__1, n, resid, &c__1, &workd[ipj], &c__1);
         cnorm.r = z__1.r, cnorm.i = z__1.i;
         rnorm1 = sqrt(dlapy2_(&cnorm.r, &cnorm.i));
     }
     else if (*bmat == 'I')
     {
-        rnorm1 = dznrm2_(n, &resid[1], &c__1);
+        rnorm1 = dznrm2_(n, resid, &c__1);
     }
 
 #ifndef NO_TRACE
@@ -815,7 +813,7 @@ L90:
         /* ----------------------------------------------- */
 
         i__1 = *n;
-        for (jj = 1; jj <= i__1; ++jj)
+        for (jj = 0; jj < i__1; ++jj)
         {
             resid[jj].r = 0.0, resid[jj].i = 0.0;
         }

--- a/src/ARPACK/arpack-ng/SRC/znapps.c
+++ b/src/ARPACK/arpack-ng/SRC/znapps.c
@@ -167,10 +167,6 @@ int znapps_(int *n, int *kev, int *np,
     static double smlnum;
 
     /* Parameter adjustments */
-    --workd;
-    --resid;
-    --workl;
-    --shift;
     v_dim = *ldv;
     v_offset = 1 + v_dim;
     v -= v_offset;
@@ -239,7 +235,8 @@ int znapps_(int *n, int *kev, int *np,
     i__1 = *np;
     for (jj = 1; jj <= i__1; ++jj)
     {
-        sigma.r = shift[jj].r, sigma.i = shift[jj].i;
+        /* TODO: fix jj - 1 */
+        sigma.r = shift[jj - 1].r, sigma.i = shift[jj - 1].i;
 
 #ifndef NO_TRACE
         if (msglvl > 2)
@@ -271,7 +268,7 @@ L20:
             if (tst1 == 0.0)
             {
                 i__3 = kplusp - jj + 1;
-                tst1 = zlanhs_("1", &i__3, &h[h_offset], ldh, &workl[1]);
+                tst1 = zlanhs_("1", &i__3, &h[h_offset], ldh, workl);
             }
             i__3 = i + 1 + i * h_dim;
             /* Computing MAX */
@@ -506,7 +503,7 @@ L100:
         tst1 = abs(d__1) + abs(d__2) + abs(d__3) + abs(d__4);
         if (tst1 == 0.0)
         {
-            tst1 = zlanhs_("1", kev, &h[h_offset], ldh, &workl[1]);
+            tst1 = zlanhs_("1", kev, &h[h_offset], ldh, workl);
         }
         i__2 = i + 1 + i * h_dim;
         /* Computing MAX */
@@ -528,7 +525,7 @@ L100:
     i__1 = *kev + 1 + *kev * h_dim;
     if (h[i__1].r > 0.0)
     {
-        zgemv_("N", n, &kplusp, &z_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &z_zero, &workd[*n + 1], &c__1);
+        zgemv_("N", n, &kplusp, &z_one, &v[v_offset], ldv, &q[(*kev + 1) * q_dim + 1], &c__1, &z_zero, &workd[*n], &c__1);
     }
 
     /* -------------------------------------------------------- */
@@ -540,8 +537,8 @@ L100:
     for (i = 1; i <= i__1; ++i)
     {
         i__2 = kplusp - i + 1;
-        zgemv_("N", n, &i__2, &z_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &z_zero, &workd[1], &c__1);
-        zcopy_(n, &workd[1], &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
+        zgemv_("N", n, &i__2, &z_one, &v[v_offset], ldv, &q[(*kev - i + 1) * q_dim + 1], &c__1, &z_zero, workd, &c__1);
+        zcopy_(n, workd, &c__1, &v[(kplusp - i + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------------------- */
@@ -557,7 +554,7 @@ L100:
     i__1 = *kev + 1 + *kev * h_dim;
     if (h[i__1].r > 0.0)
     {
-        zcopy_(n, &workd[*n + 1], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
+        zcopy_(n, &workd[*n], &c__1, &v[(*kev + 1) * v_dim + 1], &c__1);
     }
 
     /* ----------------------------------- */
@@ -568,11 +565,11 @@ L100:
     /*    betak = e_{kev+1}'*H*e_{kev}     */
     /* ----------------------------------- */
 
-    zscal_(n, &q[kplusp + *kev * q_dim], &resid[1], &c__1);
+    zscal_(n, &q[kplusp + *kev * q_dim], resid, &c__1);
     i__1 = *kev + 1 + *kev * h_dim;
     if (h[i__1].r > 0.0)
     {
-        zaxpy_(n, &h[i__1], &v[(*kev + 1) * v_dim + 1],&c__1, &resid[1], &c__1);
+        zaxpy_(n, &h[i__1], &v[(*kev + 1) * v_dim + 1],&c__1, resid, &c__1);
     }
 
 #ifndef NO_TRACE

--- a/src/ARPACK/arpack-ng/SRC/znaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/znaup2.c
@@ -745,7 +745,7 @@ L50:
     {
         ++timing_1.nbx;
         zcopy_(n, resid, &c__1, &workd[*n], &c__1);
-        /* TODO: subtract 1 */
+        /* TODO: ipntr index */
         ipntr[0] = *n + 1;
         ipntr[1] = 1;
         *ido = 2;

--- a/src/ARPACK/arpack-ng/SRC/znaup2.c
+++ b/src/ARPACK/arpack-ng/SRC/znaup2.c
@@ -173,7 +173,7 @@ int znaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
             int *info)
 {
     /* System generated locals */
-    int h_dim, h_offset, q_offset, v_offset, i__1, i__2;
+    int i__1, i__2;
     double d__1, d__2, d__3, d__4;
     zomplex z__1;
 
@@ -199,22 +199,6 @@ int znaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     int nptemp;
     char wprime[3];
     zomplex cmpnorm;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    --rwork;
-    --workl;
-    --bounds;
-    --ritz;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    h_dim = *ldh;
-    h_offset = 1 + h_dim;
-    h -= h_offset;
-    q_offset = 1 + *ldq;
-    q -= q_offset;
-    --ipntr;
 
     /* Function Body */
     if (*ido == 0)
@@ -282,7 +266,7 @@ int znaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
 
     if (getv0)
     {
-        zgetv0_(ido, bmat, &c__1, &initv, n, &c__1, &v[v_offset], ldv, &resid[1], &rnorm, &ipntr[1], &workd[1], info);
+        zgetv0_(ido, bmat, &c__1, &initv, n, &c__1, v, ldv, resid, &rnorm, ipntr, workd, info);
 
         if (*ido != 99)
         {
@@ -335,7 +319,7 @@ int znaup2_(int *ido, char *bmat, int *n, char *which, int *nev, int *np,
     /* Compute the first NEV steps of the Arnoldi factorization */
     /* -------------------------------------------------------- */
 
-    znaitr_(ido, bmat, n, &c__0, nev, mode, &resid[1], &rnorm, &v[v_offset], ldv, &h[h_offset], ldh, &ipntr[1], &workd[1], info);
+    znaitr_(ido, bmat, n, &c__0, nev, mode, resid, &rnorm, v, ldv, h, ldh, ipntr, workd, info);
 
     if (*ido != 99)
     {
@@ -393,7 +377,7 @@ L1000:
 L20:
     update = true;
 
-    znaitr_(ido, bmat, n, nev, np, mode, &resid[1], &rnorm, &v[v_offset], ldv,&h[h_offset], ldh, &ipntr[1], &workd[1], info);
+    znaitr_(ido, bmat, n, nev, np, mode, resid, &rnorm, v, ldv,h, ldh, ipntr, workd, info);
 
     if (*ido != 99)
     {
@@ -421,7 +405,7 @@ L20:
     /* of the current upper Hessenberg matrix.                */
     /* ------------------------------------------------------ */
 
-    zneigh_(&rnorm, &kplusp, &h[h_offset], ldh, &ritz[1], &bounds[1], &q[q_offset], ldq, &workl[1], &rwork[1], &ierr);
+    zneigh_(&rnorm, &kplusp, h, ldh, ritz, bounds, q, ldq, workl, rwork, &ierr);
 
     if (ierr != 0)
     {
@@ -447,8 +431,8 @@ L20:
 
     /* Computing 2nd power */
     i__1 = kplusp * kplusp;
-    zcopy_(&kplusp, &ritz[1], &c__1, &workl[i__1 + 1], &c__1);
-    zcopy_(&kplusp, &bounds[1], &c__1, &workl[i__1 + kplusp + 1], &c__1);
+    zcopy_(&kplusp, ritz, &c__1, &workl[i__1], &c__1);
+    zcopy_(&kplusp, bounds, &c__1, &workl[i__1 + kplusp], &c__1);
 
     /* ------------------------------------------------- */
     /* Select the wanted Ritz values and their bounds    */
@@ -458,7 +442,7 @@ L20:
     /* BOUNDS respectively.                              */
     /* ------------------------------------------------- */
 
-    zngets_(ishift, which, nev, np, &ritz[1], &bounds[1]);
+    zngets_(ishift, which, nev, np, ritz, bounds);
 
     /* ---------------------------------------------------------- */
     /* Convergence test: currently we use the following criteria. */
@@ -472,15 +456,13 @@ L20:
     nconv = 0;
 
     i__1 = *nev;
-    for (i = 1; i <= i__1; ++i)
+    for (i = 0; i < i__1; ++i)
     {
         /* Computing MAX */
         i__2 = *np + i;
         d__1 = eps23, d__2 = dlapy2_(&ritz[i__2].r, &ritz[i__2].i);
         rtemp = max(d__1,d__2);
-        d__1 = bounds[i__2].r;
-        d__2 = bounds[i__2].i;
-        if (dlapy2_(&d__1, &d__2) <= *tol * rtemp)
+        if (dlapy2_(&bounds[i__2].r, &bounds[i__2].i) <= *tol * rtemp)
         {
             ++nconv;
         }
@@ -493,8 +475,8 @@ L20:
         kp[1] = *np;
         kp[2] = nconv;
         ivout_(&c__3, kp, &debug_1.ndigit, "_naup2: NEV, NP, NCONV are");
-        zvout_(&kplusp, &ritz[1], &debug_1.ndigit, "_naup2: The eigenvalues of H");
-        zvout_(&kplusp, &bounds[1], &debug_1.ndigit, "_naup2: Ritz estimates of the current NCV Ritz values");
+        zvout_(&kplusp, ritz, &debug_1.ndigit, "_naup2: The eigenvalues of H");
+        zvout_(&kplusp, bounds, &debug_1.ndigit, "_naup2: Ritz estimates of the current NCV Ritz values");
     }
 #endif
 
@@ -509,7 +491,7 @@ L20:
     /* ------------------------------------------------------- */
 
     nptemp = *np;
-    for (j = 1; j <= nptemp; ++j)
+    for (j = 0; j < nptemp; ++j)
     {
         if (bounds[j].r == 0.0 && bounds[j].i == 0.0)
         {
@@ -526,8 +508,8 @@ L20:
         {
             /* Computing 2nd power */
             i__1 = kplusp * kplusp;
-            zvout_(&kplusp, &workl[i__1 + 1], &debug_1.ndigit, "_naup2: Eigenvalues computed by _neigh:");
-            zvout_(&kplusp, &workl[i__1 + kplusp + 1],&debug_1.ndigit, "_naup2: Ritz estimates computed by _neigh:");
+            zvout_(&kplusp, &workl[i__1], &debug_1.ndigit, "_naup2: Eigenvalues computed by _neigh:");
+            zvout_(&kplusp, &workl[i__1 + kplusp],&debug_1.ndigit, "_naup2: Ritz estimates computed by _neigh:");
         }
 #endif
 
@@ -542,9 +524,8 @@ L20:
         /*  Use h( 3,1 ) as storage to communicate  */
         /*  rnorm to zneupd  if needed              */
         /* ---------------------------------------- */
-        i__1 = h_dim + 3;
-        z__1.r = rnorm, z__1.i = 0.0;
-        h[i__1].r = z__1.r, h[i__1].i = z__1.i;
+        h[2].r = rnorm;
+        h[2].i = 0.0;
 
         /* -------------------------------------------- */
         /* Sort Ritz values so that converged Ritz      */
@@ -578,20 +559,20 @@ L20:
             strcpy(wprime, "LI");
         }
 
-        zsortc_(wprime, &c_true, &kplusp, &ritz[1], &bounds[1]);
+        zsortc_(wprime, &c_true, &kplusp, ritz, bounds);
 
         /* ------------------------------------------------ */
         /* Scale the Ritz estimate of each Ritz value       */
         /* by 1 / max(eps23, magnitude of the Ritz value).  */
         /* ------------------------------------------------ */
 
-        for (j = 1; j <= nev0; ++j)
+        for (j = 0; j < nev0; ++j)
         {
             /* Computing MAX */
             d__1 = eps23, d__2 = dlapy2_(&ritz[j].r, &ritz[j].i);
             rtemp = max(d__1,d__2);
-            z__1.r = bounds[j].r / rtemp, z__1.i = bounds[j].i / rtemp;
-            bounds[j].r = z__1.r, bounds[j].i = z__1.i;
+            bounds[j].r = bounds[j].r / rtemp;
+            bounds[j].i = bounds[j].i / rtemp;
         }
 
         /* ------------------------------------------------- */
@@ -602,20 +583,20 @@ L20:
         /* ------------------------------------------------- */
 
         strcpy(wprime, "LM");
-        zsortc_(wprime, &c_true, &nev0, &bounds[1], &ritz[1]);
+        zsortc_(wprime, &c_true, &nev0, bounds, ritz);
 
         /* -------------------------------------------- */
         /* Scale the Ritz estimate back to its original */
         /* value.                                       */
         /* -------------------------------------------- */
 
-        for (j = 1; j <= nev0; ++j)
+        for (j = 0; j < nev0; ++j)
         {
             /* Computing MAX */
             d__1 = eps23, d__2 = dlapy2_(&ritz[j].r, &ritz[j].i);
             rtemp = max(d__1,d__2);
-            z__1.r = rtemp * bounds[j].r, z__1.i = rtemp * bounds[j].i;
-            bounds[j].r = z__1.r, bounds[j].i = z__1.i;
+            bounds[j].r = rtemp * bounds[j].r;
+            bounds[j].i = rtemp * bounds[j].i;
         }
 
         /* --------------------------------------------- */
@@ -624,13 +605,13 @@ L20:
         /* ritz and bound.                               */
         /* --------------------------------------------- */
 
-        zsortc_(which, &c_true, &nconv, &ritz[1], &bounds[1]);
+        zsortc_(which, &c_true, &nconv, ritz, bounds);
 
 #ifndef NO_TRACE
         if (msglvl > 1)
         {
-            zvout_(&kplusp, &ritz[1], &debug_1.ndigit, "_naup2: Sorted eigenvalues");
-            zvout_(&kplusp, &bounds[1], &debug_1.ndigit, "_naup2: Sorted ritz estimates.");
+            zvout_(&kplusp, ritz, &debug_1.ndigit, "_naup2: Sorted eigenvalues");
+            zvout_(&kplusp, bounds, &debug_1.ndigit, "_naup2: Sorted ritz estimates.");
         }
 #endif
 
@@ -684,7 +665,7 @@ L20:
 
         if (nevbef < *nev)
         {
-            zngets_(ishift, which, nev, np, &ritz[1], &bounds[1]);
+            zngets_(ishift, which, nev, np, ritz, bounds);
         }
     }
 
@@ -697,8 +678,8 @@ L20:
             kp[0] = *nev;
             kp[1] = *np;
             ivout_(&c__2, kp, &debug_1.ndigit, "_naup2: NEV and NP are");
-            zvout_(nev, &ritz[*np + 1], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values ");
-            zvout_(nev, &bounds[*np + 1], &debug_1.ndigit, "_naup2: Ritz estimates of the \"wanted\" values ");
+            zvout_(nev, &ritz[*np], &debug_1.ndigit, "_naup2: \"wanted\" Ritz values ");
+            zvout_(nev, &bounds[*np], &debug_1.ndigit, "_naup2: Ritz estimates of the \"wanted\" values ");
         }
     }
 #endif
@@ -725,17 +706,17 @@ L50:
         /* for non-exact shift case.        */
         /* -------------------------------- */
 
-        zcopy_(np, &workl[1], &c__1, &ritz[1], &c__1);
+        zcopy_(np, workl, &c__1, ritz, &c__1);
     }
 
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
         ivout_(&c__1, np, &debug_1.ndigit, "_naup2: The number of shifts to apply ");
-        zvout_(np, &ritz[1], &debug_1.ndigit, "_naup2: values of the shifts");
+        zvout_(np, ritz, &debug_1.ndigit, "_naup2: values of the shifts");
         if (*ishift == 1)
         {
-            zvout_(np, &bounds[1], &debug_1.ndigit, "_naup2: Ritz estimates of the shifts");
+            zvout_(np, bounds, &debug_1.ndigit, "_naup2: Ritz estimates of the shifts");
         }
     }
 #endif
@@ -747,7 +728,7 @@ L50:
     /* The first 2*N locations of WORKD are used as workspace. */
     /* ------------------------------------------------------- */
 
-    znapps_(n, nev, np, &ritz[1], &v[v_offset], ldv, &h[h_offset], ldh, &resid[1], &q[q_offset], ldq, &workl[1], &workd[1]);
+    znapps_(n, nev, np, ritz, v, ldv, h, ldh, resid, q, ldq, workl, workd);
 
     /* ------------------------------------------- */
     /* Compute the B-norm of the updated residual. */
@@ -763,9 +744,10 @@ L50:
     if (*bmat == 'G')
     {
         ++timing_1.nbx;
-        zcopy_(n, &resid[1], &c__1, &workd[*n + 1], &c__1);
-        ipntr[1] = *n + 1;
-        ipntr[2] = 1;
+        zcopy_(n, resid, &c__1, &workd[*n], &c__1);
+        /* TODO: subtract 1 */
+        ipntr[0] = *n + 1;
+        ipntr[1] = 1;
         *ido = 2;
 
         /* -------------------------------- */
@@ -776,7 +758,7 @@ L50:
     }
     else if (*bmat == 'I')
     {
-        zcopy_(n, &resid[1], &c__1, &workd[1], &c__1);
+        zcopy_(n, resid, &c__1, workd, &c__1);
     }
 
 L100:
@@ -792,15 +774,12 @@ L100:
         arscnd_(&t3);
         timing_1.tmvbx += t3 - t2;
 #endif
-        zdotc_(&z__1, n, &resid[1], &c__1, &workd[1], &c__1);
-        cmpnorm.r = z__1.r, cmpnorm.i = z__1.i;
-        d__1 = cmpnorm.r;
-        d__2 = cmpnorm.i;
-        rnorm = sqrt(dlapy2_(&d__1, &d__2));
+        zdotc_(&cmpnorm, n, resid, &c__1, workd, &c__1);
+        rnorm = sqrt(dlapy2_(&cmpnorm.r, &cmpnorm.i));
     }
     else if (*bmat == 'I')
     {
-        rnorm = dznrm2_(n, &resid[1], &c__1);
+        rnorm = dznrm2_(n, resid, &c__1);
     }
     cnorm = false;
 
@@ -808,7 +787,7 @@ L100:
     if (msglvl > 2)
     {
         dvout_(&c__1, &rnorm, &debug_1.ndigit, "_naup2: B-norm of residual for compressed factorization");
-        zmout_(nev, nev, &h[h_offset], ldh, &debug_1.ndigit, "_naup2: Compressed upper Hessenberg matrix H");
+        zmout_(nev, nev, h, ldh, &debug_1.ndigit, "_naup2: Compressed upper Hessenberg matrix H");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/znaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/znaupd.c
@@ -383,7 +383,7 @@ int znaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 {
 
     /* System generated locals */
-    int v_offset, i__1, i__2;
+    int i__1, i__2;
 
     /* Local variables */
     int j, ierr;
@@ -394,21 +394,10 @@ int znaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 
     int ldh = *ncv;
     int ldq = *ncv;
-    int ih = 1;
-    int ritz = ih + ldh * *ncv;
+    int ritz = ldh * *ncv;
     int bounds = ritz + *ncv;
     int iq = bounds + *ncv;
     int iw = iq + ldq * *ncv;
-
-    /* Parameter adjustments */
-    --workd;
-    --resid;
-    --rwork;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
-    --iparam;
-    --ipntr;
-    --workl;
 
     /* Function Body */
     if (*ido == 0)
@@ -428,16 +417,16 @@ int znaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
         /* -------------- */
 
         ierr = 0;
-        ishift = iparam[1];
-        /*         levec  = iparam(2) */
-        mxiter = iparam[3];
-        /*         nb     = iparam(4) */
+        ishift = iparam[0];
+        /* levec  = iparam(2) */
+        mxiter = iparam[2];
+        /* nb     = iparam(4) */
 
         /* ------------------------------------------ */
         /* Revision 2 performs only implicit restart. */
         /* ------------------------------------------ */
 
-        mode = iparam[7];
+        mode = iparam[6];
 
         if (*n <= 0)
         {
@@ -524,7 +513,7 @@ int znaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
         /* Computing 2nd power */
         i__2 = *ncv;
         i__1 = i__2 * i__2 * 3 + *ncv * 5;
-        for (j = 1; j <= i__1; ++j)
+        for (j = 0; j < i__1; ++j)
         {
             workl[j].r = 0.0, workl[j].i = 0.0;
         }
@@ -548,19 +537,20 @@ int znaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 
         /* Computing 2nd power */
         i__1 = *ncv;
-        ipntr[4] = iw + i__1 * i__1 + i__1 * 3;
-        ipntr[5] = ih;
-        ipntr[6] = ritz;
-        ipntr[7] = iq;
-        ipntr[8] = bounds;
-        ipntr[14] = iw;
+        /* TODO: subtract 1 !!! */
+        ipntr[3] = 1 + iw + i__1 * i__1 + i__1 * 3;
+        ipntr[4] = 1;
+        ipntr[5] = 1 + ritz;
+        ipntr[6] = 1 + iq;
+        ipntr[7] = 1 + bounds;
+        ipntr[13] = 1 + iw;
     }
 
     /* ----------------------------------------------------- */
     /* Carry out the Implicitly restarted Arnoldi Iteration. */
     /* ----------------------------------------------------- */
 
-    znaup2_(ido, bmat, n, which, &nev0, &np, tol, &resid[1], &mode, &iupd, &ishift, &mxiter, &v[v_offset], ldv, &workl[ih], &ldh, &workl[ritz], &workl[bounds], &workl[iq], &ldq, &workl[iw], &ipntr[1], &workd[1], &rwork[1], info);
+    znaup2_(ido, bmat, n, which, &nev0, &np, tol, resid, &mode, &iupd, &ishift, &mxiter, v, ldv, workl, &ldh, &workl[ritz], &workl[bounds], &workl[iq], &ldq, &workl[iw], ipntr, workd, rwork, info);
 
     /* ------------------------------------------------ */
     /* ido .ne. 99 implies use of reverse communication */
@@ -569,18 +559,18 @@ int znaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
 
     if (*ido == 3)
     {
-        iparam[8] = np;
+        iparam[7] = np;
     }
     if (*ido != 99)
     {
         goto L9000;
     }
 
-    iparam[3] = mxiter;
-    iparam[5] = np;
-    iparam[9] = timing_1.nopx;
-    iparam[10] = timing_1.nbx;
-    iparam[11] = timing_1.nrorth;
+    iparam[2] = mxiter;
+    iparam[4] = np;
+    iparam[8] = timing_1.nopx;
+    iparam[9] = timing_1.nbx;
+    iparam[10] = timing_1.nrorth;
 
     /* ---------------------------------- */
     /* Exit if there was an informational */

--- a/src/ARPACK/arpack-ng/SRC/znaupd.c
+++ b/src/ARPACK/arpack-ng/SRC/znaupd.c
@@ -534,10 +534,9 @@ int znaupd_(int *ido, char *bmat, int *n, char *which, int *nev, double *tol,
         /* matrix.                                                     */
         /* ----------------------------------------------------------- */
 
-
         /* Computing 2nd power */
         i__1 = *ncv;
-        /* TODO: subtract 1 !!! */
+        /* TODO: ipntr index */
         ipntr[3] = 1 + iw + i__1 * i__1 + i__1 * 3;
         ipntr[4] = 1;
         ipntr[5] = 1 + ritz;

--- a/src/ARPACK/arpack-ng/SRC/zneigh.c
+++ b/src/ARPACK/arpack-ng/SRC/zneigh.c
@@ -103,7 +103,7 @@ int zneigh_(double *rnorm, int *n, zomplex *
             rwork, int *ierr)
 {
     /* System generated locals */
-    int h_offset, q_dim, q_offset, i__1;
+    int q_dim, i__1;
     double d__1;
 
     /* Local variables */
@@ -114,22 +114,12 @@ int zneigh_(double *rnorm, int *n, zomplex *
     bool select[1];
     int msglvl;
 
-
     /* ----------------------------- */
     /* Initialize timing statistics  */
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --rwork;
-    --workl;
-    --bounds;
-    --ritz;
-    h_offset = 1 + *ldh;
-    h -= h_offset;
     q_dim = *ldq;
-    q_offset = 1 + q_dim;
-    q -= q_offset;
 
     /* Function Body */
 #ifndef NO_TIMER
@@ -141,7 +131,7 @@ int zneigh_(double *rnorm, int *n, zomplex *
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
-        zmout_(n, n, &h[h_offset], ldh, &debug_1.ndigit, "_neigh: Entering upper Hessenberg matrix H ");
+        zmout_(n, n, h, ldh, &debug_1.ndigit, "_neigh: Entering upper Hessenberg matrix H ");
     }
 #endif
 
@@ -153,19 +143,19 @@ int zneigh_(double *rnorm, int *n, zomplex *
     /*    in WORKL(1:N**2), and the Schur vectors in q.         */
     /* -------------------------------------------------------- */
 
-    zlacpy_("A", n, n, &h[h_offset], ldh, &workl[1], n);
-    zlaset_("A", n, n, &z_zero, &z_one, &q[q_offset], ldq);
-    zlahqr_(&c_true, &c_true, n, &c__1, n, &workl[1], ldh, &ritz[1], &c__1, n,&q[q_offset], ldq, ierr);
+    zlacpy_("A", n, n, h, ldh, workl, n);
+    zlaset_("A", n, n, &z_zero, &z_one, q, ldq);
+    zlahqr_(&c_true, &c_true, n, &c__1, n, workl, ldh, ritz, &c__1, n,q, ldq, ierr);
     if (*ierr != 0)
     {
         goto L9000;
     }
 
-    zcopy_(n, &q[*n - 1 + q_dim], ldq, &bounds[1], &c__1);
+    zcopy_(n, &q[*n - 2], ldq, bounds, &c__1);
 #ifndef NO_TRACE
     if (msglvl > 1)
     {
-        zvout_(n, &bounds[1], &debug_1.ndigit, "_neigh: last row of the Schur matrix for H");
+        zvout_(n, bounds, &debug_1.ndigit, "_neigh: last row of the Schur matrix for H");
     }
 #endif
 
@@ -175,7 +165,7 @@ int zneigh_(double *rnorm, int *n, zomplex *
     /*    eigenvectors.                                         */
     /* -------------------------------------------------------- */
 
-    ztrevc_("R", "B", select, n, &workl[1], n, vl, n, &q[q_offset], ldq, n, n, &workl[*n * *n + 1], &rwork[1], ierr);
+    ztrevc_("R", "B", select, n, workl, n, vl, n, q, ldq, n, n, &workl[*n * *n], rwork, ierr);
 
     if (*ierr != 0)
     {
@@ -192,18 +182,18 @@ int zneigh_(double *rnorm, int *n, zomplex *
     /* ---------------------------------------------- */
 
     i__1 = *n;
-    for (j = 1; j <= i__1; ++j)
+    for (j = 0; j < i__1; ++j)
     {
-        temp = dznrm2_(n, &q[j * q_dim + 1], &c__1);
+        temp = dznrm2_(n, &q[j * q_dim], &c__1);
         d__1 = 1.0 / temp;
-        zdscal_(n, &d__1, &q[j * q_dim + 1], &c__1);
+        zdscal_(n, &d__1, &q[j * q_dim], &c__1);
     }
 
 #ifndef NO_TRACE
     if (msglvl > 1)
     {
-        zcopy_(n, &q[*n + q_dim], ldq, &workl[1], &c__1);
-        zvout_(n, &workl[1], &debug_1.ndigit, "_neigh: Last row of the eigenvector matrix for H");
+        zcopy_(n, &q[*n - 1], ldq, workl, &c__1);
+        zvout_(n, workl, &debug_1.ndigit, "_neigh: Last row of the eigenvector matrix for H");
     }
 #endif
 
@@ -211,14 +201,14 @@ int zneigh_(double *rnorm, int *n, zomplex *
     /* Compute the Ritz estimates */
     /* -------------------------- */
 
-    zcopy_(n, &q[*n + q_dim], n, &bounds[1], &c__1);
-    zdscal_(n, rnorm, &bounds[1], &c__1);
+    zcopy_(n, &q[*n - 1], n, bounds, &c__1);
+    zdscal_(n, rnorm, bounds, &c__1);
 
 #ifndef NO_TRACE
     if (msglvl > 2)
     {
-        zvout_(n, &ritz[1], &debug_1.ndigit, "_neigh: The eigenvalues of H");
-        zvout_(n, &bounds[1], &debug_1.ndigit, "_neigh: Ritz estimates for the eigenvalues of H");
+        zvout_(n, ritz, &debug_1.ndigit, "_neigh: The eigenvalues of H");
+        zvout_(n, bounds, &debug_1.ndigit, "_neigh: Ritz estimates for the eigenvalues of H");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/SRC/zneupd.c
+++ b/src/ARPACK/arpack-ng/SRC/zneupd.c
@@ -258,7 +258,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
             int *info)
 {
     /* System generated locals */
-    int v_offset, z_offset, i__1, i__2;
+    int i__1, i__2;
     double d__1, d__2, d__3, d__4;
     zomplex z__1, z__2;
 
@@ -287,10 +287,6 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
 
 
     /* Parameter adjustments */
-    z_offset = 1 + *ldz;
-    z -= z_offset;
-    v_offset = 1 + *ldv;
-    v -= v_offset;
     --select;
     --workl;
 
@@ -644,8 +640,8 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
         /* NCONV in workl(iuptri).                                */
         /* ------------------------------------------------------ */
 
-        zunm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &v[v_offset], ldv, &workd[*n], &ierr);
-        zlacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
+        zunm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, v, ldv, &workd[*n], &ierr);
+        zlacpy_("A", n, &nconv, v, ldv, z, ldz);
 
         for (j = 1; j <= nconv; ++j)
         {
@@ -747,7 +743,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
             /* Form Z*Q.                                    */
             /* -------------------------------------------- */
 
-            ztrmm_("R", "U", "N", "N", n, &nconv, &z_one, &workl[invsub], &ldq, &z[z_offset], ldz);
+            ztrmm_("R", "U", "N", "N", n, &nconv, &z_one, &workl[invsub], &ldq, z, ldz);
         }
     }
     else
@@ -862,7 +858,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
         /* purify all the Ritz vectors together. */
         /* ------------------------------------- */
 
-        zgeru_(n, &nconv, &z_one, resid, &c__1, workev, &c__1, &z[z_offset], ldz);
+        zgeru_(n, &nconv, &z_one, resid, &c__1, workev, &c__1, z, ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/zneupd.c
+++ b/src/ARPACK/arpack-ng/SRC/zneupd.c
@@ -287,24 +287,17 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
 
 
     /* Parameter adjustments */
-    --workd;
-    --resid;
     z_offset = 1 + *ldz;
     z -= z_offset;
-    --d;
-    --rwork;
-    --workev;
-    --select;
     v_offset = 1 + *ldv;
     v -= v_offset;
-    --iparam;
-    --ipntr;
+    --select;
     --workl;
 
     /* Function Body */
     msglvl = debug_1.mceupd;
-    mode = iparam[7];
-    nconv = iparam[5];
+    mode = iparam[6];
+    nconv = iparam[4];
     *info = 0;
 
     /* ------------------------------- */
@@ -420,20 +413,20 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
     /* GRAND total of NCV * ( 3 * NCV + 4 ) locations.           */
     /* --------------------------------------------------------- */
 
-    ih = ipntr[5];
-    ritz = ipntr[6];
-    iq = ipntr[7];
-    bounds = ipntr[8];
+    ih = ipntr[4];
+    ritz = ipntr[5];
+    iq = ipntr[6];
+    bounds = ipntr[7];
     ldh = *ncv;
     ldq = *ncv;
     iheig = bounds + ldh;
     ihbds = iheig + ldh;
     iuptri = ihbds + ldh;
     invsub = iuptri + ldh * *ncv;
-    ipntr[9] = iheig;
-    ipntr[11] = ihbds;
-    ipntr[12] = iuptri;
-    ipntr[13] = invsub;
+    ipntr[8] = iheig;
+    ipntr[10] = ihbds;
+    ipntr[11] = iuptri;
+    ipntr[12] = invsub;
     wr = 1;
     iwev = wr + *ncv;
 
@@ -445,7 +438,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
     /*     _naup2.                             */
     /* --------------------------------------- */
 
-    irz = ipntr[14] + *ncv * *ncv;
+    irz = ipntr[13] + *ncv * *ncv;
     ibd = irz + *ncv;
 
     /* ---------------------------------- */
@@ -588,7 +581,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
             /* Reorder the computed upper triangular matrix. */
             /* --------------------------------------------- */
 
-            ztrsen_("N", "V", &select[1], ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq, &workl[iheig], &nconv2, &conds, &sep,&workev[1], ncv, &ierr);
+            ztrsen_("N", "V", &select[1], ncv, &workl[iuptri], &ldh, &workl[invsub], &ldq, &workl[iheig], &nconv2, &conds, &sep,workev, ncv, &ierr);
 
             if (nconv2 < nconv)
             {
@@ -628,7 +621,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
 
         if (strcmp(type, "REGULR") == 0)
         {
-            zcopy_(&nconv, &workl[iheig], &c__1, &d[1], &c__1);
+            zcopy_(&nconv, &workl[iheig], &c__1, d, &c__1);
         }
 
         /* -------------------------------------------------------- */
@@ -637,7 +630,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
         /* columns of workl(invsub,ldq).                            */
         /* -------------------------------------------------------- */
 
-        zgeqr2_(ncv, &nconv, &workl[invsub], &ldq, &workev[1], &workev[*ncv + 1], &ierr);
+        zgeqr2_(ncv, &nconv, &workl[invsub], &ldq, workev, &workev[*ncv], &ierr);
 
         /* ------------------------------------------------------ */
         /* * Postmultiply V by Q using zunm2r.                    */
@@ -651,7 +644,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
         /* NCONV in workl(iuptri).                                */
         /* ------------------------------------------------------ */
 
-        zunm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, &workev[1], &v[v_offset], ldv, &workd[*n + 1], &ierr);
+        zunm2r_("R", "N", n, ncv, &nconv, &workl[invsub], &ldq, workev, &v[v_offset], ldv, &workd[*n], &ierr);
         zlacpy_("A", n, &nconv, &v[v_offset], ldv, &z[z_offset], ldz);
 
         for (j = 1; j <= nconv; ++j)
@@ -668,9 +661,9 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
             i__2 = invsub + (j - 1) * ldq + j - 1;
             if (workl[i__2].r < 0.0)
             {
-                z__1.r = -1., z__1.i = -0.0;
+                z__1.r = -1.0, z__1.i = -0.0;
                 zscal_(&nconv, &z__1, &workl[iuptri + j - 1], &ldq);
-                z__1.r = -1., z__1.i = -0.0;
+                z__1.r = -1.0, z__1.i = -0.0;
                 zscal_(&nconv, &z__1, &workl[iuptri + (j - 1) * ldq], &c__1);
             }
         }
@@ -695,7 +688,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
                 }
             }
 
-            ztrevc_("R", "S", &select[1], ncv, &workl[iuptri], &ldq, vl, &c__1, &workl[invsub], &ldq, ncv, &outncv, &workev[1],&rwork[1], &ierr);
+            ztrevc_("R", "S", &select[1], ncv, &workl[iuptri], &ldq, vl, &c__1, &workl[invsub], &ldq, ncv, &outncv, workev,rwork, &ierr);
 
             if (ierr != 0)
             {
@@ -711,11 +704,11 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
             /* magnitude 1.                                   */
             /* ---------------------------------------------- */
 
-            for (j = 1; j <= nconv; ++j)
+            for (j = 0; j < nconv; ++j)
             {
-                rtemp = dznrm2_(ncv, &workl[invsub + (j - 1) * ldq], &c__1);
+                rtemp = dznrm2_(ncv, &workl[invsub + j * ldq], &c__1);
                 rtemp = 1.0 / rtemp;
-                zdscal_(ncv, &rtemp, &workl[invsub + (j - 1) * ldq], &c__1);
+                zdscal_(ncv, &rtemp, &workl[invsub + j * ldq], &c__1);
 
                 /* ---------------------------------------- */
                 /* Ritz estimates can be obtained by taking */
@@ -726,9 +719,9 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
                 /* inner product can be set to j.           */
                 /* ---------------------------------------- */
 
-                i__2 = j;
-                zdotc_(&z__1, &j, &workl[ihbds], &c__1, &workl[invsub + (j - 1) * ldq], &c__1);
-                workev[i__2].r = z__1.r, workev[i__2].i = z__1.i;
+                i__2 = j + 1;
+                zdotc_(&z__1, &i__2, &workl[ihbds], &c__1, &workl[invsub + j * ldq], &c__1);
+                workev[j].r = z__1.r, workev[j].i = z__1.i;
             }
 
 #ifndef NO_TRACE
@@ -747,7 +740,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
             /* Copy Ritz estimates into workl(ihbds) */
             /* ------------------------------------- */
 
-            zcopy_(&nconv, &workev[1], &c__1, &workl[ihbds], &c__1);
+            zcopy_(&nconv, workev, &c__1, &workl[ihbds], &c__1);
 
             /* -------------------------------------------- */
             /* The eigenvector matrix Q of T is triangular. */
@@ -764,7 +757,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
         /* Place the Ritz values computed ZNAUPD into D.    */
         /* ------------------------------------------------ */
 
-        zcopy_(&nconv, &workl[ritz], &c__1, &d[1], &c__1);
+        zcopy_(&nconv, &workl[ritz], &c__1, d, &c__1);
         zcopy_(&nconv, &workl[ritz], &c__1, &workl[iheig], &c__1);
         zcopy_(&nconv, &workl[bounds], &c__1, &workl[ihbds], &c__1);
     }
@@ -796,12 +789,12 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
         }
 
         i__1 = *ncv;
-        for (k = 1; k <= i__1; ++k)
+        for (k = 0; k < i__1; ++k)
         {
-            i__2 = iheig + k - 1;
+            i__2 = iheig + k;
             temp.r = workl[i__2].r, temp.i = workl[i__2].i;
-            i__2 = ihbds + k - 1;
-            z_div(&z__2, &workl[ihbds + k - 1], &temp);
+            i__2 = ihbds + k;
+            z_div(&z__2, &workl[ihbds + k], &temp);
             z_div(&z__1, &z__2, &temp);
             workl[i__2].r = z__1.r, workl[i__2].i = z__1.i;
         }
@@ -817,23 +810,23 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
 
     if (strcmp(type, "SHIFTI") == 0)
     {
-        for (k = 1; k <= nconv; ++k)
+        for (k = 0; k < nconv; ++k)
         {
-            z_div(&z__2, &z_one, &workl[iheig + k - 1]);
-            z__1.r = z__2.r + sigma->r, z__1.i = z__2.i + sigma->i;
-            d[k].r = z__1.r, d[k].i = z__1.i;
+            z_div(&z__2, &z_one, &workl[iheig + k]);
+            d[k].r = z__2.r + sigma->r;
+            d[k].i = z__2.i + sigma->i;
         }
     }
 
 #ifndef NO_TRACE
     if (msglvl > 1 && strcmp(type, "REGULR") != 0)
     {
-        zvout_(&nconv, &d[1], &debug_1.ndigit, "_neupd: Untransformed Ritz values.");
+        zvout_(&nconv, d, &debug_1.ndigit, "_neupd: Untransformed Ritz values.");
         zvout_(&nconv, &workl[ihbds], &debug_1.ndigit, "_neupd: Ritz estimates of the untransformed Ritz values.");
     }
     else if (msglvl > 1)
     {
-        zvout_(&nconv, &d[1], &debug_1.ndigit, "_neupd: Converged Ritz values.");
+        zvout_(&nconv, d, &debug_1.ndigit, "_neupd: Converged Ritz values.");
         zvout_(&nconv, &workl[ihbds], &debug_1.ndigit, "_neupd: Associated Ritz estimates.");
     }
 #endif
@@ -855,12 +848,12 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
         /* where H s = s theta.                           */
         /* ---------------------------------------------- */
 
-        for (j = 1; j <= nconv; ++j)
+        for (j = 0; j < nconv; ++j)
         {
-            i__2 = iheig + j - 1;
-            if (workl[i__2].r != 0. || workl[i__2].i != 0.0)
+            i__2 = iheig + j;
+            if (workl[i__2].r != 0.0 || workl[i__2].i != 0.0)
             {
-                z_div(&z__1, &workl[invsub + (j - 1) * ldq + *ncv - 1], &workl[i__2]);
+                z_div(&z__1, &workl[invsub + j * ldq + *ncv - 1], &workl[i__2]);
                 workev[j].r = z__1.r, workev[j].i = z__1.i;
             }
         }
@@ -869,7 +862,7 @@ int zneupd_(bool *rvec, char *howmny, bool *select, zomplex *d, zomplex *z, int 
         /* purify all the Ritz vectors together. */
         /* ------------------------------------- */
 
-        zgeru_(n, &nconv, &z_one, &resid[1], &c__1, &workev[1], &c__1, &z[z_offset], ldz);
+        zgeru_(n, &nconv, &z_one, resid, &c__1, workev, &c__1, &z[z_offset], ldz);
     }
 
 L9000:

--- a/src/ARPACK/arpack-ng/SRC/zngets.c
+++ b/src/ARPACK/arpack-ng/SRC/zngets.c
@@ -100,10 +100,6 @@ int zngets_(int *ishift, char *which, int *kev, int *np, zomplex *ritz,
     /* & message level for debugging */
     /* ----------------------------- */
 
-    /* Parameter adjustments */
-    --bounds;
-    --ritz;
-
     /* Function Body */
 #ifndef NO_TIMER
     arscnd_(&t0);
@@ -112,7 +108,7 @@ int zngets_(int *ishift, char *which, int *kev, int *np, zomplex *ritz,
     msglvl = debug_1.mcgets;
 
     i__1 = *kev + *np;
-    zsortc_(which, &c_true, &i__1, &ritz[1], &bounds[1]);
+    zsortc_(which, &c_true, &i__1, ritz, bounds);
 
     if (*ishift == 1)
     {
@@ -125,7 +121,7 @@ int zngets_(int *ishift, char *which, int *kev, int *np, zomplex *ritz,
         /* Be careful and use 'SM' since we want to sort BOUNDS! */
         /* ----------------------------------------------------- */
 
-        zsortc_("SM", &c_true, np, &bounds[1], &ritz[1]);
+        zsortc_("SM", &c_true, np, bounds, ritz);
     }
 
 #ifndef NO_TIMER
@@ -138,8 +134,8 @@ int zngets_(int *ishift, char *which, int *kev, int *np, zomplex *ritz,
     {
         ivout_(&c__1, kev, &debug_1.ndigit, "_ngets: KEV is");
         ivout_(&c__1, np, &debug_1.ndigit, "_ngets: NP is");
-        zvout_(&i__1, &ritz[1], &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix ");
-        zvout_(&i__1, &bounds[1], &debug_1.ndigit, "_ngets: Ritz estimates of the current KEV+NP Ritz values");
+        zvout_(&i__1, ritz, &debug_1.ndigit, "_ngets: Eigenvalues of current H matrix ");
+        zvout_(&i__1, bounds, &debug_1.ndigit, "_ngets: Ritz estimates of the current KEV+NP Ritz values");
     }
 #endif
 

--- a/src/ARPACK/arpack-ng/UTIL/cmout.c
+++ b/src/ARPACK/arpack-ng/UTIL/cmout.c
@@ -18,36 +18,28 @@
  */
 int cmout_(int *m, int *n, complex *a, int *lda, int *idigit, char *ifmt)
 {
-    /* Initialized data */
-
+    /* System generated locals */
     complex d__1;
 
-    /* System generated locals */
-    int a_dim, a_offset, i__1, i__3;
-
     /* Local variables */
-    int i, j, k1, k2, lll;
+    int i, j, k1, k2, len, p;
     char line[80];
     int ndigit;
     int cols = *n;
     int rows = *m;
 
-    /* Parameter adjustments */
-    a_dim = *lda;
-    a_offset = 1 + a_dim;
-    a -= a_offset;
+    int a_dim = *lda;
 
     /* Function Body */
 
-    /* Computing MIN */
-    i__1 = strlen(ifmt);
-    lll = min(i__1,79);
-    i__1 = lll;
-    for (i = 1; i <= i__1; ++i)
+    len = strlen(ifmt);
+    len = min(len,80);
+    for (i = 0; i < len; ++i)
     {
-        line[i - 1] = '-';
+        line[i] = '-';
     }
-    line[lll] = '\0';
+    i = min(i,79);
+    line[i] = '\0';
 
     printf("\n %s\n %s", ifmt, line);
 
@@ -72,20 +64,19 @@ int cmout_(int *m, int *n, complex *a, int *lda, int *idigit, char *ifmt)
 
     if (ndigit <= 4)
     {
-        for (k1 = 1; k1 <= cols; k1 += 2)
+        for (k1 = 0; k1 < cols; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(cols,i__3);
+            p = k1 + 2;
+            k2 = min(cols,p);
             printf("\n           ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("          Col %4d         ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     d__1 = a[i + j * a_dim];
                     printf("(  %10.3e   %10.3e)  ", d__1.r, d__1.i);
@@ -95,20 +86,19 @@ int cmout_(int *m, int *n, complex *a, int *lda, int *idigit, char *ifmt)
     }
     else if (ndigit <= 6)
     {
-        for (k1 = 1; k1 <= cols; k1 += 2)
+        for (k1 = 0; k1 < cols; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(cols,i__3);
+            p = k1 + 2;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("            Col %4d           ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     d__1 = a[i + j * a_dim];
                     printf("(  %12.5e   %12.5e)  ", d__1.r, d__1.i);
@@ -118,20 +108,19 @@ int cmout_(int *m, int *n, complex *a, int *lda, int *idigit, char *ifmt)
     }
     else if (ndigit <= 8)
     {
-        for (k1 = 1; k1 <= cols; k1 += 2)
+        for (k1 = 0; k1 < cols; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(cols,i__3);
+            p = k1 + 2;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("              Col %4d             ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     d__1 = a[i + j * a_dim];
                     printf("(  %14.7e   %14.7e)  ", d__1.r, d__1.i);
@@ -141,10 +130,10 @@ int cmout_(int *m, int *n, complex *a, int *lda, int *idigit, char *ifmt)
     }
     else
     {
-        for (k1 = 1; k1 <= cols; ++k1)
+        for (k1 = 0; k1 < cols; ++k1)
         {
             printf("                               Col %4d                  ", i);
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 d__1 = a[i + k1 * a_dim];
                 printf("\n  Row %4d:  (  %20.13e   %20.13e)", i, d__1.r, d__1.i);

--- a/src/ARPACK/arpack-ng/UTIL/cvout.c
+++ b/src/ARPACK/arpack-ng/UTIL/cvout.c
@@ -15,33 +15,25 @@
  */
 int cvout_(int *n, complex *cx, int *idigit, char *ifmt)
 {
-
-    /* System generated locals */
-    int i__1, i__3;
-
     /* Local variables */
-    int i, k1, k2, lll;
+    int i, k1, k2, len, m;
     char line[80];
     int ndigit;
-    int len = *n;
-
-    /* Parameter adjustments */
-    --cx;
 
     /* Function Body */
-    /* Computing MIN */
-    i__1 = strlen(ifmt);
-    lll = min(i__1,79);
-    i__1 = lll;
-    for (i = 1; i <= i__1; ++i)
+    len = strlen(ifmt);
+    len = min(len,80);
+    for (i = 0; i < len; ++i)
     {
-        line[i - 1] = '-';
+        line[i] = '-';
     }
-    line[lll] = '\0';
+    i = min(i,79);
+    line[i] = '\0';
 
     printf("\n %s\n %s", ifmt, line);
 
-    if (*n <= 0)
+    len = *n;
+    if (len <= 0)
     {
         return 0;
     }
@@ -62,13 +54,12 @@ int cvout_(int *n, complex *cx, int *idigit, char *ifmt)
 
     if (ndigit <= 4)
     {
-        for (k1 = 1; k1 <= len; k1 += 2)
+        for (k1 = 0; k1 < len; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(len,i__3);
+            m = k1 + 2;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:  ", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("(  %10.3e   %10.3e)  ", cx[i].r, cx[i].i);
             }
@@ -76,13 +67,12 @@ int cvout_(int *n, complex *cx, int *idigit, char *ifmt)
     }
     else if (ndigit <= 6)
     {
-        for (k1 = 1; k1 <= len; k1 += 2)
+        for (k1 = 0; k1 < len; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(len,i__3);
+            m = k1 + 2;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:  ", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("(  %12.5e   %12.5e)  ", cx[i].r, cx[i].i);
             }
@@ -90,13 +80,12 @@ int cvout_(int *n, complex *cx, int *idigit, char *ifmt)
     }
     else if (ndigit <= 8)
     {
-        for (k1 = 1; k1 <= len; k1 += 2)
+        for (k1 = 0; k1 < len; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(len,i__3);
+            m = k1 + 2;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:  ", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("(  %14.7e   %14.7e)  ", cx[i].r, cx[i].i);
             }
@@ -104,9 +93,9 @@ int cvout_(int *n, complex *cx, int *idigit, char *ifmt)
     }
     else
     {
-        for (k1 = 1; k1 <= len; ++k1)
+        for (k1 = 0; k1 < len; ++k1)
         {
-            printf("  %4d:  (  %20.13e   %20.13e)  ", k1, cx[i].r, cx[i].i);
+            printf("\n  %4d:  (  %20.13e   %20.13e)  ", k1, cx[i].r, cx[i].i);
         }
     }
 

--- a/src/ARPACK/arpack-ng/UTIL/dmout.c
+++ b/src/ARPACK/arpack-ng/UTIL/dmout.c
@@ -18,34 +18,25 @@
  */
 int dmout_(int *m, int *n, double *a, int *lda, int *idigit, char *ifmt)
 {
-    /* Initialized data */
-
-    /* System generated locals */
-    int a_dim, a_offset, i__1, i__3;
-
     /* Local variables */
-    int i, j, k1, k2, lll;
+    int i, j, k1, k2, len, p;
     char line[80];
     int ndigit;
     int cols = *n;
     int rows = *m;
 
-    /* Parameter adjustments */
-    a_dim = *lda;
-    a_offset = 1 + a_dim;
-    a -= a_offset;
+    int a_dim = *lda;
 
     /* Function Body */
 
-    /* Computing MIN */
-    i__1 = strlen(ifmt);
-    lll = min(i__1,79);
-    i__1 = lll;
-    for (i = 1; i <= i__1; ++i)
+    len = strlen(ifmt);
+    len = min(len,80);
+    for (i = 0; i < len; ++i)
     {
-        line[i - 1] = '-';
+        line[i] = '-';
     }
-    line[lll] = '\0';
+    i = min(i,79);
+    line[i] = '\0';
 
     printf("\n %s\n %s", ifmt, line);
 
@@ -70,20 +61,19 @@ int dmout_(int *m, int *n, double *a, int *lda, int *idigit, char *ifmt)
 
     if (ndigit <= 4)
     {
-        for (k1 = 1; k1 <= cols; k1 += 5)
+        for (k1 = 0; k1 < cols; k1 += 5)
         {
-            /* Computing MIN */
-            i__3 = k1 + 4;
-            k2 = min(cols,i__3);
+            p = k1 + 5;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("     Col %4d ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     printf(" %12.3e", a[i + j * a_dim]);
                 }
@@ -92,20 +82,19 @@ int dmout_(int *m, int *n, double *a, int *lda, int *idigit, char *ifmt)
     }
     else if (ndigit <= 6)
     {
-        for (k1 = 1; k1 <= cols; k1 += 4)
+        for (k1 = 0; k1 < cols; k1 += 4)
         {
-            /* Computing MIN */
-            i__3 = k1 + 3;
-            k2 = min(cols,i__3);
+            p = k1 + 4;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("      Col %4d  ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     printf(" %14.5e", a[i + j * a_dim]);
                 }
@@ -114,20 +103,19 @@ int dmout_(int *m, int *n, double *a, int *lda, int *idigit, char *ifmt)
     }
     else if (ndigit <= 10)
     {
-        for (k1 = 1; k1 <= cols; k1 += 3)
+        for (k1 = 0; k1 < cols; k1 += 3)
         {
-            /* Computing MIN */
-            i__3 = k1 + 2;
-            k2 = min(cols,i__3);
+            p = k1 + 3;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("        Col %4d    ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     printf(" %18.9e", a[i + j * a_dim]);
                 }
@@ -136,20 +124,19 @@ int dmout_(int *m, int *n, double *a, int *lda, int *idigit, char *ifmt)
     }
     else
     {
-        for (k1 = 1; k1 <= cols; k1 += 2)
+        for (k1 = 0; k1 < cols; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(cols,i__3);
+            p = k1 + 2;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("          Col %4d      ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     printf(" %22.13e", a[i + j * a_dim]);
                 }

--- a/src/ARPACK/arpack-ng/UTIL/dvout.c
+++ b/src/ARPACK/arpack-ng/UTIL/dvout.c
@@ -15,33 +15,25 @@
  */
 int dvout_(int *n, double *sx, int *idigit, char *ifmt)
 {
-
-    /* System generated locals */
-    int i__1, i__3;
-
     /* Local variables */
-    int i, k1, k2, lll;
+    int i, k1, k2, len, m;
     char line[80];
     int ndigit;
-    int len = *n;
-
-    /* Parameter adjustments */
-    --sx;
 
     /* Function Body */
-    /* Computing MIN */
-    i__1 = strlen(ifmt);
-    lll = min(i__1,79);
-    i__1 = lll;
-    for (i = 1; i <= i__1; ++i)
+    len = strlen(ifmt);
+    len = min(len,80);
+    for (i = 0; i < len; ++i)
     {
-        line[i - 1] = '-';
+        line[i] = '-';
     }
-    line[lll] = '\0';
+    i = min(i,79);
+    line[i] = '\0';
 
     printf("\n %s\n %s", ifmt, line);
 
-    if (*n <= 0)
+    len = *n;
+    if (len <= 0)
     {
         return 0;
     }
@@ -62,13 +54,12 @@ int dvout_(int *n, double *sx, int *idigit, char *ifmt)
 
     if (ndigit <= 4)
     {
-        for (k1 = 1; k1 <= len; k1 += 5)
+        for (k1 = 0; k1 < len; k1 += 5)
         {
-            /* Computing MIN */
-            i__3 = k1 + 4;
-            k2 = min(len,i__3);
+            m = k1 + 5;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf(" %12.3e", sx[i]);
             }
@@ -76,13 +67,12 @@ int dvout_(int *n, double *sx, int *idigit, char *ifmt)
     }
     else if (ndigit <= 6)
     {
-        for (k1 = 1; k1 <= len; k1 += 4)
+        for (k1 = 0; k1 < len; k1 += 4)
         {
-            /* Computing MIN */
-            i__3 = k1 + 3;
-            k2 = min(len,i__3);
+            m = k1 + 4;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf(" %14.5e", sx[i]);
             }
@@ -90,13 +80,12 @@ int dvout_(int *n, double *sx, int *idigit, char *ifmt)
     }
     else if (ndigit <= 10)
     {
-        for (k1 = 1; k1 <= len; k1 += 3)
+        for (k1 = 0; k1 < len; k1 += 3)
         {
-            /* Computing MIN */
-            i__3 = k1 + 2;
-            k2 = min(len,i__3);
+            m = k1 + 3;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf(" %18.9e", sx[i]);
             }
@@ -104,13 +93,12 @@ int dvout_(int *n, double *sx, int *idigit, char *ifmt)
     }
     else
     {
-        for (k1 = 1; k1 <= len; k1 += 2)
+        for (k1 = 0; k1 < len; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(len,i__3);
+            m = k1 + 2;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf(" %24.13e", sx[i]);
             }

--- a/src/ARPACK/arpack-ng/UTIL/ivout.c
+++ b/src/ARPACK/arpack-ng/UTIL/ivout.c
@@ -15,33 +15,25 @@
  */
 int ivout_(int *n, int *ix, int *idigit, char *ifmt)
 {
-
-    /* System generated locals */
-    int i__1, i__3;
-
     /* Local variables */
-    int i, k1, k2, lll;
+    int i, k1, k2, len, m;
     char line[80];
     int ndigit;
-    int len = *n;
-
-    /* Parameter adjustments */
-    --ix;
 
     /* Function Body */
-    /* Computing MIN */
-    i__1 = strlen(ifmt);
-    lll = min(i__1,79);
-    i__1 = lll;
-    for (i = 1; i <= i__1; ++i)
+    len = strlen(ifmt);
+    len = min(len,80);
+    for (i = 0; i < len; ++i)
     {
-        line[i - 1] = '-';
+        line[i] = '-';
     }
-    line[lll] = '\0';
+    i = min(i,79);
+    line[i] = '\0';
 
     printf("\n %s\n %s", ifmt, line);
 
-    if (*n <= 0)
+    len = *n;
+    if (len <= 0)
     {
         return 0;
     }
@@ -63,13 +55,12 @@ int ivout_(int *n, int *ix, int *idigit, char *ifmt)
 
     if (ndigit <= 4)
     {
-        for (k1 = 1; k1 <= len; k1 += 10)
+        for (k1 = 0; k1 < len; k1 += 10)
         {
-            /* Computing MIN */
-            i__3 = k1 + 9;
-            k2 = min(len,i__3);
+            m = k1 + 10;
+            k2 = min(len,m);
             printf("\n  %4d - %4d: ", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("   %5d", ix[i]);
             }
@@ -77,13 +68,12 @@ int ivout_(int *n, int *ix, int *idigit, char *ifmt)
     }
     else if (ndigit <= 6)
     {
-        for (k1 = 1; k1 <= len; k1 += 7)
+        for (k1 = 0; k1 < len; k1 += 7)
         {
-            /* Computing MIN */
-            i__3 = k1 + 6;
-            k2 = min(len,i__3);
+            m = k1 + 7;
+            k2 = min(len,m);
             printf("\n  %4d - %4d: ", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("  %7d", ix[i]);
             }
@@ -91,13 +81,12 @@ int ivout_(int *n, int *ix, int *idigit, char *ifmt)
     }
     else if (ndigit <= 10)
     {
-        for (k1 = 1; k1 <= len; k1 += 5)
+        for (k1 = 0; k1 < len; k1 += 5)
         {
-            /* Computing MIN */
-            i__3 = k1 + 4;
-            k2 = min(len,i__3);
+            m = k1 + 5;
+            k2 = min(len,m);
             printf("\n  %4d - %4d: ", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("  %11d", ix[i]);
             }
@@ -105,13 +94,12 @@ int ivout_(int *n, int *ix, int *idigit, char *ifmt)
     }
     else
     {
-        for (k1 = 1; k1 <= len; k1 += 3)
+        for (k1 = 0; k1 < len; k1 += 3)
         {
-            /* Computing MIN */
-            i__3 = k1 + 2;
-            k2 = min(len,i__3);
+            m = k1 + 3;
+            k2 = min(len,m);
             printf("\n  %4d - %4d: ", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("  %15d", ix[i]);
             }

--- a/src/ARPACK/arpack-ng/UTIL/smout.c
+++ b/src/ARPACK/arpack-ng/UTIL/smout.c
@@ -18,34 +18,25 @@
  */
 int smout_(int *m, int *n, float *a, int *lda, int *idigit, char *ifmt)
 {
-    /* Initialized data */
-
-    /* System generated locals */
-    int a_dim, a_offset, i__1, i__3;
-
     /* Local variables */
-    int i, j, k1, k2, lll;
+    int i, j, k1, k2, len, p;
     char line[80];
     int ndigit;
     int cols = *n;
     int rows = *m;
 
-    /* Parameter adjustments */
-    a_dim = *lda;
-    a_offset = 1 + a_dim;
-    a -= a_offset;
+    int a_dim = *lda;
 
     /* Function Body */
 
-    /* Computing MIN */
-    i__1 = strlen(ifmt);
-    lll = min(i__1,79);
-    i__1 = lll;
-    for (i = 1; i <= i__1; ++i)
+    len = strlen(ifmt);
+    len = min(len,80);
+    for (i = 0; i < len; ++i)
     {
-        line[i - 1] = '-';
+        line[i] = '-';
     }
-    line[lll] = '\0';
+    i = min(i,79);
+    line[i] = '\0';
 
     printf("\n %s\n %s", ifmt, line);
 
@@ -70,20 +61,20 @@ int smout_(int *m, int *n, float *a, int *lda, int *idigit, char *ifmt)
 
     if (ndigit <= 4)
     {
-        for (k1 = 1; k1 <= cols; k1 += 5)
+        for (k1 = 0; k1 < cols; k1 += 5)
         {
             /* Computing MIN */
-            i__3 = k1 + 4;
-            k2 = min(cols,i__3);
+            p = k1 + 5;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("     Col %4d ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     printf(" %12.3e", a[i + j * a_dim]);
                 }
@@ -92,20 +83,20 @@ int smout_(int *m, int *n, float *a, int *lda, int *idigit, char *ifmt)
     }
     else if (ndigit <= 6)
     {
-        for (k1 = 1; k1 <= cols; k1 += 4)
+        for (k1 = 0; k1 < cols; k1 += 4)
         {
             /* Computing MIN */
-            i__3 = k1 + 3;
-            k2 = min(cols,i__3);
+            p = k1 + 4;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("      Col %4d  ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     printf(" %14.5e", a[i + j * a_dim]);
                 }
@@ -114,20 +105,20 @@ int smout_(int *m, int *n, float *a, int *lda, int *idigit, char *ifmt)
     }
     else if (ndigit <= 10)
     {
-        for (k1 = 1; k1 <= cols; k1 += 3)
+        for (k1 = 0; k1 < cols; k1 += 3)
         {
             /* Computing MIN */
-            i__3 = k1 + 2;
-            k2 = min(cols,i__3);
+            p = k1 + 3;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("        Col %4d    ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     printf(" %18.9e", a[i + j * a_dim]);
                 }
@@ -136,20 +127,19 @@ int smout_(int *m, int *n, float *a, int *lda, int *idigit, char *ifmt)
     }
     else
     {
-        for (k1 = 1; k1 <= cols; k1 += 2)
+        for (k1 = 0; k1 < cols; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(cols,i__3);
+            p = k1 + 2;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("          Col %4d      ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     printf(" %22.13e", a[i + j * a_dim]);
                 }

--- a/src/ARPACK/arpack-ng/UTIL/svout.c
+++ b/src/ARPACK/arpack-ng/UTIL/svout.c
@@ -15,33 +15,25 @@
  */
 int svout_(int *n, float *sx, int *idigit, char *ifmt)
 {
-
-    /* System generated locals */
-    int i__1, i__3;
-
     /* Local variables */
-    int i, k1, k2, lll;
+    int i, k1, k2, len, m;
     char line[80];
     int ndigit;
-    int len = *n;
-
-    /* Parameter adjustments */
-    --sx;
 
     /* Function Body */
-    /* Computing MIN */
-    i__1 = strlen(ifmt);
-    lll = min(i__1,79);
-    i__1 = lll;
-    for (i = 1; i <= i__1; ++i)
+    len = strlen(ifmt);
+    len = min(len,80);
+    for (i = 0; i < len; ++i)
     {
-        line[i - 1] = '-';
+        line[i] = '-';
     }
-    line[lll] = '\0';
+    i = min(i,79);
+    line[i] = '\0';
 
     printf("\n %s\n %s", ifmt, line);
 
-    if (*n <= 0)
+    len = *n;
+    if (len <= 0)
     {
         return 0;
     }
@@ -62,13 +54,12 @@ int svout_(int *n, float *sx, int *idigit, char *ifmt)
 
     if (ndigit <= 4)
     {
-        for (k1 = 1; k1 <= len; k1 += 5)
+        for (k1 = 0; k1 < len; k1 += 5)
         {
-            /* Computing MIN */
-            i__3 = k1 + 4;
-            k2 = min(len,i__3);
+            m = k1 + 5;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf(" %12.3e", sx[i]);
             }
@@ -76,13 +67,12 @@ int svout_(int *n, float *sx, int *idigit, char *ifmt)
     }
     else if (ndigit <= 6)
     {
-        for (k1 = 1; k1 <= len; k1 += 4)
+        for (k1 = 0; k1 < len; k1 += 4)
         {
-            /* Computing MIN */
-            i__3 = k1 + 3;
-            k2 = min(len,i__3);
+            m = k1 + 4;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf(" %14.5e", sx[i]);
             }
@@ -90,13 +80,12 @@ int svout_(int *n, float *sx, int *idigit, char *ifmt)
     }
     else if (ndigit <= 10)
     {
-        for (k1 = 1; k1 <= len; k1 += 3)
+        for (k1 = 0; k1 < len; k1 += 3)
         {
-            /* Computing MIN */
-            i__3 = k1 + 2;
-            k2 = min(len,i__3);
+            m = k1 + 3;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf(" %18.9e", sx[i]);
             }
@@ -104,13 +93,12 @@ int svout_(int *n, float *sx, int *idigit, char *ifmt)
     }
     else
     {
-        for (k1 = 1; k1 <= len; k1 += 2)
+        for (k1 = 0; k1 < len; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(len,i__3);
+            m = k1 + 2;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf(" %24.13e", sx[i]);
             }

--- a/src/ARPACK/arpack-ng/UTIL/zmout.c
+++ b/src/ARPACK/arpack-ng/UTIL/zmout.c
@@ -18,36 +18,28 @@
  */
 int zmout_(int *m, int *n, zomplex *a, int *lda, int *idigit, char *ifmt)
 {
-    /* Initialized data */
-
+    /* System generated locals */
     zomplex d__1;
 
-    /* System generated locals */
-    int a_dim, a_offset, i__1, i__3;
-
     /* Local variables */
-    int i, j, k1, k2, lll;
+    int i, j, k1, k2, len, p;
     char line[80];
     int ndigit;
     int cols = *n;
     int rows = *m;
 
-    /* Parameter adjustments */
-    a_dim = *lda;
-    a_offset = 1 + a_dim;
-    a -= a_offset;
+    int a_dim = *lda;
 
     /* Function Body */
 
-    /* Computing MIN */
-    i__1 = strlen(ifmt);
-    lll = min(i__1,79);
-    i__1 = lll;
-    for (i = 1; i <= i__1; ++i)
+    len = strlen(ifmt);
+    len = min(len,80);
+    for (i = 0; i < len; ++i)
     {
-        line[i - 1] = '-';
+        line[i] = '-';
     }
-    line[lll] = '\0';
+    i = min(i,79);
+    line[i] = '\0';
 
     printf("\n %s\n %s", ifmt, line);
 
@@ -72,20 +64,19 @@ int zmout_(int *m, int *n, zomplex *a, int *lda, int *idigit, char *ifmt)
 
     if (ndigit <= 4)
     {
-        for (k1 = 1; k1 <= cols; k1 += 2)
+        for (k1 = 0; k1 < cols; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(cols,i__3);
+            p = k1 + 2;
+            k2 = min(cols, p);
             printf("\n           ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("          Col %4d         ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     d__1 = a[i + j * a_dim];
                     printf("(  %10.3e   %10.3e)  ", d__1.r, d__1.i);
@@ -95,20 +86,19 @@ int zmout_(int *m, int *n, zomplex *a, int *lda, int *idigit, char *ifmt)
     }
     else if (ndigit <= 6)
     {
-        for (k1 = 1; k1 <= cols; k1 += 2)
+        for (k1 = 0; k1 < cols; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(cols,i__3);
+            p = k1 + 2;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("            Col %4d           ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     d__1 = a[i + j * a_dim];
                     printf("(  %12.5e   %12.5e)  ", d__1.r, d__1.i);
@@ -118,20 +108,19 @@ int zmout_(int *m, int *n, zomplex *a, int *lda, int *idigit, char *ifmt)
     }
     else if (ndigit <= 8)
     {
-        for (k1 = 1; k1 <= cols; k1 += 2)
+        for (k1 = 0; k1 < cols; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(cols,i__3);
+            p = k1 + 2;
+            k2 = min(cols,p);
             printf("\n          ");
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("              Col %4d             ", i);
             }
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 printf("\n  Row %4d:  ", i);
-                for (j = k1; j <= k2; ++j)
+                for (j = k1; j < k2; ++j)
                 {
                     d__1 = a[i + j * a_dim];
                     printf("(  %14.7e   %14.7e)  ", d__1.r, d__1.i);
@@ -141,10 +130,10 @@ int zmout_(int *m, int *n, zomplex *a, int *lda, int *idigit, char *ifmt)
     }
     else
     {
-        for (k1 = 1; k1 <= cols; ++k1)
+        for (k1 = 0; k1 < cols; ++k1)
         {
             printf("                               Col %4d                  ", i);
-            for (i = 1; i <= rows; ++i)
+            for (i = 0; i < rows; ++i)
             {
                 d__1 = a[i + k1 * a_dim];
                 printf("\n  Row %4d:  (  %20.13e   %20.13e)", i, d__1.r, d__1.i);

--- a/src/ARPACK/arpack-ng/UTIL/zvout.c
+++ b/src/ARPACK/arpack-ng/UTIL/zvout.c
@@ -15,33 +15,25 @@
  */
 int zvout_(int *n, zomplex *cx, int *idigit, char *ifmt)
 {
-
-    /* System generated locals */
-    int i__1, i__3;
-
     /* Local variables */
-    int i, k1, k2, lll;
+    int i, k1, k2, len, m;
     char line[80];
     int ndigit;
-    int len = *n;
-
-    /* Parameter adjustments */
-    --cx;
 
     /* Function Body */
-    /* Computing MIN */
-    i__1 = strlen(ifmt);
-    lll = min(i__1,79);
-    i__1 = lll;
-    for (i = 1; i <= i__1; ++i)
+    len = strlen(ifmt);
+    len = min(len,80);
+    for (i = 0; i < len; ++i)
     {
-        line[i - 1] = '-';
+        line[i] = '-';
     }
-    line[lll] = '\0';
+    i = min(i,79);
+    line[i] = '\0';
 
     printf("\n %s\n %s", ifmt, line);
 
-    if (*n <= 0)
+    len = *n;
+    if (len <= 0)
     {
         return 0;
     }
@@ -62,13 +54,12 @@ int zvout_(int *n, zomplex *cx, int *idigit, char *ifmt)
 
     if (ndigit <= 4)
     {
-        for (k1 = 1; k1 <= len; k1 += 2)
+        for (k1 = 0; k1 < len; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(len,i__3);
+            m = k1 + 2;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:  ", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("(  %10.3e   %10.3e)  ", cx[i].r, cx[i].i);
             }
@@ -76,13 +67,12 @@ int zvout_(int *n, zomplex *cx, int *idigit, char *ifmt)
     }
     else if (ndigit <= 6)
     {
-        for (k1 = 1; k1 <= len; k1 += 2)
+        for (k1 = 0; k1 < len; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(len,i__3);
+            m = k1 + 2;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:  ", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("(  %12.5e   %12.5e)  ", cx[i].r, cx[i].i);
             }
@@ -90,13 +80,12 @@ int zvout_(int *n, zomplex *cx, int *idigit, char *ifmt)
     }
     else if (ndigit <= 8)
     {
-        for (k1 = 1; k1 <= len; k1 += 2)
+        for (k1 = 0; k1 < len; k1 += 2)
         {
-            /* Computing MIN */
-            i__3 = k1 + 1;
-            k2 = min(len,i__3);
+            m = k1 + 2;
+            k2 = min(len,m);
             printf("\n  %4d - %4d:  ", k1, k2);
-            for (i = k1; i <= k2; ++i)
+            for (i = k1; i < k2; ++i)
             {
                 printf("(  %14.7e   %14.7e)  ", cx[i].r, cx[i].i);
             }
@@ -104,9 +93,9 @@ int zvout_(int *n, zomplex *cx, int *idigit, char *ifmt)
     }
     else
     {
-        for (k1 = 1; k1 <= len; ++k1)
+        for (k1 = 0; k1 < len; ++k1)
         {
-            printf("  %4d:  (  %20.13e   %20.13e)  ", k1, cx[i].r, cx[i].i);
+            printf("\n  %4d:  (  %20.13e   %20.13e)  ", k1, cx[i].r, cx[i].i);
         }
     }
 


### PR DESCRIPTION
Convert Fortran to C (0-based) indexing.

Not all occurances are removed, especially where `ipntr` array is used for indexing.